### PR TITLE
mod conversion: add converter and unit

### DIFF
--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -1,0 +1,40 @@
+use bitcoin::Network;
+
+/// Converter purpose is to give a Conversion from a given amount in satoshis according to its
+/// parameters.
+pub struct Converter {
+    pub unit: Unit,
+}
+
+impl Converter {
+    pub fn new(bitcoin_network: Network) -> Self {
+        let unit = match bitcoin_network {
+            Network::Testnet => Unit::TestnetBitcoin,
+            Network::Bitcoin => Unit::Bitcoin,
+            Network::Regtest => Unit::RegtestBitcoin,
+        };
+        Self { unit }
+    }
+
+    /// converts amount in satoshis to BTC float.
+    pub fn converts(&self, amount: u64) -> f64 {
+        bitcoin::Amount::from_sat(amount).as_btc()
+    }
+}
+
+/// Unit is the bitcoin ticker according to the network used.
+pub enum Unit {
+    TestnetBitcoin,
+    RegtestBitcoin,
+    Bitcoin,
+}
+
+impl std::fmt::Display for Unit {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::TestnetBitcoin => write!(f, "tBTC"),
+            Self::RegtestBitcoin => write!(f, "rBTC"),
+            Self::Bitcoin => write!(f, "BTC"),
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use tracing_subscriber::filter::EnvFilter;
 extern crate serde;
 extern crate serde_json;
 
+mod conversion;
 mod revault;
 mod revaultd;
 mod ui;

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -14,9 +14,7 @@ use super::state::{
     State,
 };
 
-use crate::revault::Role;
-use crate::revaultd::RevaultD;
-use crate::ui::view::Context;
+use crate::{conversion::Converter, revault::Role, revaultd::RevaultD, ui::view::Context};
 
 pub struct App {
     config: Config,
@@ -73,7 +71,7 @@ impl Application for App {
                 state: std::boxed::Box::new(state),
                 revaultd: None,
                 clipboard: ClipboardContext::new().expect("Failed to get clipboard provider"),
-                context: Context::new(true, Role::Manager, Menu::Home),
+                context: Context::default(),
             },
             cmd,
         )
@@ -94,7 +92,13 @@ impl Application for App {
                 self.state.load()
             }
             Message::Synced(revaultd) => {
-                self.context.network = revaultd.network();
+                self.context = Context::new(
+                    Converter::new(revaultd.network()),
+                    revaultd.network(),
+                    true,
+                    Role::Manager,
+                    Menu::Home,
+                );
                 self.context.network_up = true;
                 self.revaultd = Some(revaultd);
                 self.load_state(Role::Manager, Menu::Home)

--- a/src/ui/view/manager.rs
+++ b/src/ui/view/manager.rs
@@ -7,6 +7,7 @@ use crate::ui::{
     component::{button, card, separation, text},
     menu::Menu,
     message::{InputMessage, Message, RecipientMessage},
+    view::Context,
 };
 
 #[derive(Debug)]
@@ -303,6 +304,7 @@ impl ManagerSelectInputsView {
 }
 
 pub fn manager_send_input_view<'a>(
+    ctx: &Context,
     outpoint: &str,
     amount: &u64,
     selected: bool,
@@ -313,7 +315,7 @@ pub fn manager_send_input_view<'a>(
         .push(checkbox)
         .push(text::bold(text::simple(&format!(
             "{}",
-            *amount as f64 / 100000000_f64
+            ctx.converter.converts(*amount)
         ))))
         .spacing(20);
     Container::new(row).width(Length::Fill).into()

--- a/src/ui/view/mod.rs
+++ b/src/ui/view/mod.rs
@@ -19,9 +19,13 @@ pub use stakeholder::{StakeholderACKDepositView, StakeholderACKFundsView};
 use bitcoin::Network;
 
 use super::menu::Menu;
-use crate::revault::Role;
+use crate::{conversion::Converter, revault::Role};
 
+/// Context stores display informations and features
+/// used directly by views. It does not store anything
+/// related to Revault logic.
 pub struct Context {
+    pub converter: Converter,
     pub network: Network,
     pub network_up: bool,
     pub menu: Menu,
@@ -30,13 +34,33 @@ pub struct Context {
 }
 
 impl Context {
-    pub fn new(role_edit: bool, role: Role, menu: Menu) -> Self {
+    pub fn new(
+        converter: Converter,
+        network: Network,
+        role_edit: bool,
+        role: Role,
+        menu: Menu,
+    ) -> Self {
         Self {
+            converter,
             role,
             role_edit,
             menu,
-            network: bitcoin::Network::Bitcoin,
+            network,
             network_up: false,
+        }
+    }
+}
+
+impl std::default::Default for Context {
+    fn default() -> Self {
+        Context {
+            converter: Converter::new(Network::Bitcoin),
+            network: Network::Bitcoin,
+            network_up: false,
+            role: Role::Manager,
+            menu: Menu::Home,
+            role_edit: false,
         }
     }
 }

--- a/src/ui/view/stakeholder.rs
+++ b/src/ui/view/stakeholder.rs
@@ -65,7 +65,7 @@ impl StakeholderACKFundsView {
 }
 
 pub fn stakeholder_deposit_signed<'a>(
-    _ctx: &Context,
+    ctx: &Context,
     deposit: &Vault,
 ) -> Element<'a, DepositMessage> {
     card::white(Container::new(
@@ -90,9 +90,9 @@ pub fn stakeholder_deposit_signed<'a>(
                     Row::new()
                         .push(text::success(text::bold(text::simple(&format!(
                             "{}",
-                            deposit.amount as f64 / 100000000_f64
+                            ctx.converter.converts(deposit.amount),
                         )))))
-                        .push(text::small(" BTC"))
+                        .push(text::small(&format!(" {}", ctx.converter.unit)))
                         .align_items(Align::Center),
                 )
                 .width(Length::Shrink),
@@ -104,7 +104,7 @@ pub fn stakeholder_deposit_signed<'a>(
 }
 
 pub fn stakeholder_deposit_pending<'a>(
-    _ctx: &Context,
+    ctx: &Context,
     deposit: &Vault,
 ) -> Element<'a, DepositMessage> {
     card::white(Container::new(
@@ -127,9 +127,9 @@ pub fn stakeholder_deposit_pending<'a>(
                     Row::new()
                         .push(text::bold(text::simple(&format!(
                             "{}",
-                            deposit.amount as f64 / 100000000_f64
+                            ctx.converter.converts(deposit.amount),
                         ))))
-                        .push(text::small(" BTC"))
+                        .push(text::small(&format!(" {}", ctx.converter.unit)))
                         .align_items(Align::Center),
                 )
                 .width(Length::Shrink),
@@ -154,7 +154,7 @@ impl StakeholderACKDepositView {
 
     pub fn view<'a>(
         &'a mut self,
-        _ctx: &Context,
+        ctx: &Context,
         warning: Option<&String>,
         deposit: &Vault,
         emergency_tx: &(PartiallySignedTransaction, bool),
@@ -267,9 +267,9 @@ impl StakeholderACKDepositView {
                             Row::new()
                                 .push(text::bold(text::simple(&format!(
                                     "{}",
-                                    deposit.amount as f64 / 100000000_f64
+                                    ctx.converter.converts(deposit.amount)
                                 ))))
-                                .push(text::small(" BTC"))
+                                .push(text::small(&format!(" {}", ctx.converter.unit)))
                                 .align_items(Align::Center),
                         )
                         .width(Length::Shrink),

--- a/src/ui/view/vault.rs
+++ b/src/ui/view/vault.rs
@@ -30,7 +30,7 @@ impl VaultView {
         txs: &VaultTransactions,
     ) -> Element<Message> {
         match self {
-            Self::ListItem(v) => v.view(vault),
+            Self::ListItem(v) => v.view(ctx, vault),
             Self::Modal(v) => v.view(ctx, vault, txs),
         }
     }
@@ -122,9 +122,12 @@ impl VaultModal {
                                                     Row::new()
                                                         .push(text::bold(text::simple(&format!(
                                                             "{}",
-                                                            vlt.amount as f64 / 100000000_f64
+                                                            ctx.converter.converts(vlt.amount),
                                                         ))))
-                                                        .push(text::simple(" BTC")),
+                                                        .push(text::simple(&format!(
+                                                            "{}",
+                                                            ctx.converter.unit,
+                                                        ))),
                                                 )
                                                 .width(Length::Shrink),
                                             )
@@ -209,7 +212,7 @@ fn input_and_outputs<'a, T: 'a>(
             col = col.push(text::small(&format!("{}", &output.script_pubkey)))
         }
         col_output = col_output.push(card::simple(Container::new(col.push(text::bold(
-            text::small(&format!("{}", output.value as f64 / 100000000_f64)),
+            text::small(&format!("{}", ctx.converter.converts(output.value))),
         )))));
     }
     Container::new(Row::new().push(col_input).push(col_output).spacing(20))
@@ -227,7 +230,7 @@ impl VaultListItem {
         }
     }
 
-    pub fn view(&mut self, vault: &Vault) -> iced::Element<Message> {
+    pub fn view(&mut self, ctx: &Context, vault: &Vault) -> iced::Element<Message> {
         card::rounded(Container::new(
             button::transparent(
                 &mut self.state,
@@ -242,18 +245,15 @@ impl VaultListItem {
                             )
                             .width(Length::Fill),
                         )
-                        .push(
-                            Container::new(
-                                Row::new()
-                                    .push(text::bold(text::simple(&format!(
-                                        "{}",
-                                        vault.amount as f64 / 100000000_f64
-                                    ))))
-                                    .push(text::small(" BTC"))
-                                    .align_items(Align::Center),
-                            )
-                            .width(Length::Shrink),
-                        )
+                        .push(Container::new(
+                            Row::new()
+                                .push(text::bold(text::simple(&format!(
+                                    "{}",
+                                    ctx.converter.converts(vault.amount)
+                                ))))
+                                .push(text::small(&format!(" {}", ctx.converter.unit)))
+                                .align_items(Align::Center),
+                        ))
                         .spacing(20)
                         .align_items(Align::Center),
                 )),


### PR DESCRIPTION
A converter converts a given amount in satoshis
to another amount in a chosen unit.
This struct can be enhanced with currency
conversion.

Converter is shared to each view through the Context,
because it is only a display feature and does not have
core revault logic.

close #32