### PR TITLE
Add a REVAULTD_PATH environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,4 @@ default `revaultd` configuration location is checked.
 | `REVAULTD_CONF`       | Path to the [revaultd](https://github.com/revault/revaultd) configuration path                                                                                          |
 | `REVAULTGUI_DEBUG`    | If `true`, the interface will use `iced` debug feature to display current layout and set log level to `debug`                                                            |
 | `REVAULTGUI_LOG`      | Enable the [tracing env filter](https://docs.rs/tracing-subscriber/0.2.15/tracing_subscriber/filter/struct.EnvFilter.html) example: `revault_gui::revault::client=debug` |
+| `REVAULTD_PATH`       | Path to the [revaultd](https://github.com/revault/revaultd) binary                                                                                                      |

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # revault-gui
 
 Revault GUI is an user graphical interface written in rust for the 
-[Revault daemon](https:://github.com/re-vault/revaultd).
+[Revault daemon](https:://github.com/revault/revaultd).
 
 ## Get started
 
@@ -13,6 +13,6 @@ default `revaultd` configuration location is checked.
 
 | Var                   | Description                                                                                                                                                              |
 | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `REVAULTD_CONF`       | Path to the [revaultd](https://github.com/re-vault/revaultd) configuration path                                                                                          |
+| `REVAULTD_CONF`       | Path to the [revaultd](https://github.com/revault/revaultd) configuration path                                                                                          |
 | `REVAULTGUI_DEBUG`    | If `true`, the interface will use `iced` debug feature to display current layout and set log level to `debug`                                                            |
 | `REVAULTGUI_LOG`      | Enable the [tracing env filter](https://docs.rs/tracing-subscriber/0.2.15/tracing_subscriber/filter/struct.EnvFilter.html) example: `revault_gui::revault::client=debug` |

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ mod revaultd;
 mod ui;
 
 fn main() {
-    let path = match std::env::var("REVAULTD_CONF") {
+    let revaultd_config_path = match std::env::var("REVAULTD_CONF") {
         Ok(p) => Some(PathBuf::from(p)),
         Err(VarError::NotPresent) => None,
         Err(VarError::NotUnicode(_)) => {
@@ -58,6 +58,15 @@ fn main() {
         }
     };
 
+    let revaultd_path = match std::env::var("REVAULTD_PATH") {
+        Ok(p) => Some(PathBuf::from(p)),
+        Err(VarError::NotUnicode(_)) => {
+            println!("Error: REVAULTD_PATH unicode only");
+            std::process::exit(1);
+        }
+        Err(VarError::NotPresent) => None,
+    };
+
     let subscriber = tracing_subscriber::FmtSubscriber::builder()
         .with_env_filter(logfilter)
         .finish();
@@ -68,7 +77,8 @@ fn main() {
     }
 
     if let Err(e) = ui::app::run(ui::app::Config {
-        revaultd_config_path: path,
+        revaultd_config_path,
+        revaultd_path,
         debug,
     }) {
         println!("Error: failed to launch UI: {}", e.to_string());

--- a/src/revaultd/mod.rs
+++ b/src/revaultd/mod.rs
@@ -176,9 +176,9 @@ pub struct ListOnchainTransactionsResponse {
 }
 
 // RevaultD can start only if a config path is given.
-pub async fn start_daemon(config_path: &Path) -> Result<(), RevaultDError> {
+pub async fn start_daemon(config_path: &Path, revaultd_path: &Path) -> Result<(), RevaultDError> {
     debug!("starting revaultd daemon");
-    let child = Command::new("revaultd")
+    let child = Command::new(revaultd_path)
         .arg("--conf")
         .arg(config_path.to_path_buf().into_os_string().as_os_str())
         .spawn()

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -62,7 +62,10 @@ impl Application for App {
     type Flags = Config;
 
     fn new(config: Config) -> (App, Command<Self::Message>) {
-        let state = ChargingState::new(config.revaultd_config_path.to_owned());
+        let state = ChargingState::new(
+            config.revaultd_config_path.to_owned(),
+            config.revaultd_path.to_owned(),
+        );
         let cmd = state.load();
         (
             App {
@@ -121,5 +124,6 @@ impl Application for App {
 #[derive(Debug, Clone)]
 pub struct Config {
     pub revaultd_config_path: Option<PathBuf>,
+    pub revaultd_path: Option<PathBuf>,
     pub debug: bool,
 }


### PR DESCRIPTION
Add an environment variable for specifying revaultd path. When revaultd
isn't running, uses this variable to start the binary. If not provided,
the gui will call the `revaultd` command.

Fixes #18 