### PR TITLE
UI add delegate panel

### DIFF
--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -10,8 +10,8 @@ use super::menu::Menu;
 use super::message::Message;
 use super::state::{
     ChargingState, DepositState, HistoryState, InstallingState, ManagerHomeState,
-    ManagerNetworkState, ManagerSendState, StakeholderACKFundsState, StakeholderHomeState,
-    StakeholderNetworkState, State,
+    ManagerNetworkState, ManagerSendState, StakeholderACKFundsState, StakeholderDelegateFundsState,
+    StakeholderHomeState, StakeholderNetworkState, State,
 };
 
 use crate::{conversion::Converter, revault::Role, revaultd::RevaultD, ui::view::Context};
@@ -41,6 +41,8 @@ impl App {
                 Menu::History => HistoryState::new(revaultd).into(),
                 Menu::Network => ManagerNetworkState::new(revaultd).into(),
                 Menu::Send => ManagerSendState::new(revaultd).into(),
+                // Manager cannot delegate funds, the user is redirected to the home.
+                Menu::DelegateFunds => ManagerHomeState::new(revaultd).into(),
                 _ => unreachable!(),
             },
             Role::Stakeholder => match self.context.menu {
@@ -49,6 +51,7 @@ impl App {
                 Menu::History => HistoryState::new(revaultd).into(),
                 Menu::Network => StakeholderNetworkState::new(revaultd).into(),
                 Menu::ACKFunds => StakeholderACKFundsState::new(revaultd).into(),
+                Menu::DelegateFunds => StakeholderDelegateFundsState::new(revaultd).into(),
                 _ => unreachable!(),
             },
         };

--- a/src/ui/component/button.rs
+++ b/src/ui/component/button.rs
@@ -1,5 +1,5 @@
 use crate::ui::{color, component::text, icon::clipboard_icon};
-use iced::{button, Color, Container, Row, Text, Vector};
+use iced::{button, Color, Container, Row, Vector};
 
 macro_rules! button {
     ($name:ident, $style_name:ident, $bg_color:expr, $text_color:expr) => {
@@ -47,7 +47,7 @@ button!(
 
 pub fn button_content<'a, T: 'a>(icon: Option<iced::Text>, text: &str) -> Container<'a, T> {
     match icon {
-        None => Container::new(Text::new(text)).padding(5),
+        None => Container::new(text::simple(text)).padding(5),
         Some(i) => Container::new(
             Row::new()
                 .push(i)

--- a/src/ui/icon.rs
+++ b/src/ui/icon.rs
@@ -70,6 +70,10 @@ pub fn shield_check_icon() -> Text {
     icon('\u{F509}')
 }
 
+pub fn person_check_icon() -> Text {
+    icon('\u{F4AF}')
+}
+
 #[allow(dead_code)]
 pub fn stakeholder_icon() -> Text {
     icon('\u{F4AE}')

--- a/src/ui/menu.rs
+++ b/src/ui/menu.rs
@@ -6,4 +6,5 @@ pub enum Menu {
     Network,
     Send,
     ACKFunds,
+    DelegateFunds,
 }

--- a/src/ui/message.rs
+++ b/src/ui/message.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use super::{error::Error, menu::Menu};
 use crate::revault::Role;
 use crate::revaultd::{
-    model::{RevocationTransactions, Vault, VaultTransactions},
+    model::{RevocationTransactions, UnvaultTransaction, Vault, VaultStatus, VaultTransactions},
     RevaultD, RevaultDError,
 };
 
@@ -16,8 +16,8 @@ pub enum Message {
     Synced(Arc<RevaultD>),
     DaemonStarted(Result<Arc<RevaultD>, Error>),
     Vaults(Result<Vec<Vault>, RevaultDError>),
-    SelectVault(String),
     Vault(VaultMessage),
+    FilterVaults(VaultFilterMessage),
     BlockHeight(Result<u64, RevaultDError>),
     Connected(Result<Arc<RevaultD>, Error>),
     Menu(Menu),
@@ -32,15 +32,35 @@ pub enum Message {
 
 #[derive(Debug, Clone)]
 pub enum VaultMessage {
+    ListOnchainTransaction,
     OnChainTransactions(Result<VaultTransactions, RevaultDError>),
+    UnvaultTransaction(Result<UnvaultTransaction, RevaultDError>),
+    Sign(SignMessage),
+    Signed(Result<(), RevaultDError>),
+    Select(String),
+    Delegate(String),
+}
+
+#[derive(Debug, Clone)]
+pub enum VaultFilterMessage {
+    Status(Vec<VaultStatus>),
 }
 
 #[derive(Debug, Clone)]
 pub enum SignMessage {
     ChangeMethod,
     Sign,
+    Success,
+    SharingStatus(SignatureSharingStatus),
     Clipboard(String),
     PsbtEdited(String),
+}
+
+#[derive(Debug, Clone)]
+pub enum SignatureSharingStatus {
+    Unshared,
+    Processing,
+    Success,
 }
 
 #[derive(Debug, Clone)]

--- a/src/ui/state/cmd.rs
+++ b/src/ui/state/cmd.rs
@@ -2,7 +2,7 @@ use bitcoin::util::psbt::PartiallySignedTransaction as Psbt;
 use std::sync::Arc;
 
 use crate::revaultd::{
-    model::{RevocationTransactions, Vault, VaultStatus, VaultTransactions},
+    model::{RevocationTransactions, UnvaultTransaction, Vault, VaultStatus, VaultTransactions},
     RevaultD, RevaultDError,
 };
 
@@ -53,4 +53,19 @@ pub async fn set_revocation_txs(
     cancel_tx: Psbt,
 ) -> Result<(), RevaultDError> {
     revaultd.set_revocation_txs(&outpoint, &emergency_tx, &emergency_unvault_tx, &cancel_tx)
+}
+
+pub async fn get_unvault_tx(
+    revaultd: Arc<RevaultD>,
+    outpoint: String,
+) -> Result<UnvaultTransaction, RevaultDError> {
+    revaultd.get_unvault_tx(&outpoint)
+}
+
+pub async fn set_unvault_tx(
+    revaultd: Arc<RevaultD>,
+    outpoint: String,
+    unvault_tx: Psbt,
+) -> Result<(), RevaultDError> {
+    revaultd.set_unvault_tx(&outpoint, &unvault_tx)
 }

--- a/src/ui/state/mod.rs
+++ b/src/ui/state/mod.rs
@@ -15,7 +15,10 @@ pub use deposit::DepositState;
 pub use history::HistoryState;
 pub use installing::InstallingState;
 pub use manager::{ManagerHomeState, ManagerNetworkState, ManagerSendState};
-pub use stakeholder::{StakeholderACKFundsState, StakeholderHomeState, StakeholderNetworkState};
+pub use stakeholder::{
+    StakeholderACKFundsState, StakeholderDelegateFundsState, StakeholderHomeState,
+    StakeholderNetworkState,
+};
 
 use super::{message::Message, view::Context};
 

--- a/src/ui/view/mod.rs
+++ b/src/ui/view/mod.rs
@@ -16,7 +16,10 @@ pub use history::HistoryView;
 pub use home::{ManagerHomeView, StakeholderHomeView};
 pub use manager::ManagerSendView;
 pub use network::{ManagerNetworkView, StakeholderNetworkView};
-pub use stakeholder::{StakeholderACKDepositView, StakeholderACKFundsView};
+pub use stakeholder::{
+    StakeholderACKDepositView, StakeholderACKFundsView, StakeholderDelegateFundsView,
+};
+pub use vault::VaultView;
 
 use bitcoin::Network;
 

--- a/src/ui/view/sidebar.rs
+++ b/src/ui/view/sidebar.rs
@@ -1,10 +1,11 @@
-use iced::{pick_list, Column, Container, Length, Row};
+use iced::{pick_list, Container, Length, Row};
 
 use crate::revault::Role;
 use crate::ui::{
     component::{button, separation, text, TransparentPickListStyle},
     icon::{
-        deposit_icon, dot_icon, history_icon, home_icon, network_icon, send_icon, settings_icon,
+        deposit_icon, dot_icon, history_icon, home_icon, network_icon, person_check_icon,
+        send_icon, settings_icon,
     },
     menu::Menu,
     message::Message,
@@ -15,6 +16,7 @@ use crate::ui::{
 pub struct Sidebar {
     pick_role: pick_list::State<Role>,
     deposit_menu_button: iced::button::State,
+    delegate_menu_button: iced::button::State,
     home_menu_button: iced::button::State,
     history_menu_button: iced::button::State,
     network_menu_button: iced::button::State,
@@ -26,6 +28,7 @@ impl Sidebar {
     pub fn new() -> Self {
         Sidebar {
             deposit_menu_button: iced::button::State::new(),
+            delegate_menu_button: iced::button::State::new(),
             home_menu_button: iced::button::State::new(),
             history_menu_button: iced::button::State::new(),
             network_menu_button: iced::button::State::new(),
@@ -126,8 +129,24 @@ impl Sidebar {
                 .on_press(Message::Menu(Menu::Send))
                 .width(iced::Length::Units(200)),
             )
+        } else if context.menu == Menu::DelegateFunds {
+            Container::new(
+                button::primary(
+                    &mut self.delegate_menu_button,
+                    button::button_content(Some(person_check_icon()), "Delegate funds"),
+                )
+                .on_press(Message::Menu(Menu::DelegateFunds))
+                .width(iced::Length::Units(200)),
+            )
         } else {
-            Container::new(Column::new())
+            Container::new(
+                button::transparent(
+                    &mut self.delegate_menu_button,
+                    button::button_content(Some(person_check_icon()), "Delegate funds"),
+                )
+                .on_press(Message::Menu(Menu::DelegateFunds))
+                .width(iced::Length::Units(200)),
+            )
         };
         layout::sidebar(
             layout::sidebar_menu(vec![

--- a/src/ui/view/stakeholder.rs
+++ b/src/ui/view/stakeholder.rs
@@ -2,14 +2,15 @@ use iced::{scrollable, Align, Column, Container, Element, Length, Row, Scrollabl
 
 use bitcoin::util::psbt::PartiallySignedTransaction;
 
-use crate::revaultd::model::Vault;
+use crate::revaultd::model::{Vault, VaultStatus};
 
 use crate::ui::{
-    component::{badge, button, card, separation, text, ContainerBackgroundStyle},
+    component::{badge, button, card, navbar, separation, text, ContainerBackgroundStyle},
+    error::Error,
     icon,
     menu::Menu,
-    message::{DepositMessage, Message},
-    view::Context,
+    message::{DepositMessage, Message, VaultFilterMessage},
+    view::{layout, sidebar::Sidebar, Context},
 };
 
 #[derive(Debug)]
@@ -302,5 +303,124 @@ impl StakeholderACKDepositView {
         }
 
         card::white(Container::new(col)).into()
+    }
+}
+
+#[derive(Debug)]
+pub struct StakeholderDelegateFundsView {
+    sidebar: Sidebar,
+    scroll: scrollable::State,
+    active_vaults_button: iced::button::State,
+    secured_vaults_button: iced::button::State,
+}
+
+impl StakeholderDelegateFundsView {
+    pub fn new() -> Self {
+        StakeholderDelegateFundsView {
+            sidebar: Sidebar::new(),
+            scroll: scrollable::State::new(),
+            active_vaults_button: iced::button::State::new(),
+            secured_vaults_button: iced::button::State::new(),
+        }
+    }
+
+    pub fn view<'a>(
+        &'a mut self,
+        ctx: &Context,
+        active_balance: &u64,
+        vaults: Vec<Element<'a, Message>>,
+        warning: Option<&Error>,
+        display_delegated: &bool,
+    ) -> Element<'a, Message> {
+        let mut vaults_header = Row::new()
+            .push(
+                Container::new(text::simple(&format!("{} vaults", vaults.len())))
+                    .width(Length::Fill),
+            )
+            .align_items(Align::Center);
+        if *display_delegated {
+            vaults_header = vaults_header
+                .push(
+                    button::transparent(
+                        &mut self.secured_vaults_button,
+                        button::button_content(None, "Available vaults"),
+                    )
+                    .on_press(Message::FilterVaults(
+                        VaultFilterMessage::Status(vec![VaultStatus::Secured]),
+                    )),
+                )
+                .push(
+                    button::primary(
+                        &mut self.active_vaults_button,
+                        button::button_content(None, "Delegated vaults"),
+                    )
+                    .on_press(Message::FilterVaults(
+                        VaultFilterMessage::Status(vec![
+                            VaultStatus::Active,
+                            VaultStatus::Unvaulting,
+                            VaultStatus::Unvaulted,
+                        ]),
+                    )),
+                );
+        } else {
+            vaults_header = vaults_header
+                .push(
+                    button::primary(
+                        &mut self.secured_vaults_button,
+                        button::button_content(None, "Available vaults"),
+                    )
+                    .on_press(Message::FilterVaults(
+                        VaultFilterMessage::Status(vec![VaultStatus::Secured]),
+                    )),
+                )
+                .push(
+                    button::transparent(
+                        &mut self.active_vaults_button,
+                        button::button_content(None, "Delegated vaults"),
+                    )
+                    .on_press(Message::FilterVaults(
+                        VaultFilterMessage::Status(vec![
+                            VaultStatus::Active,
+                            VaultStatus::Unvaulting,
+                            VaultStatus::Unvaulted,
+                        ]),
+                    )),
+                );
+        }
+        let col = Column::new()
+            .push(
+                card::white(Container::new(
+                    Column::new()
+                        .push(
+                            Row::new()
+                                .push(text::bold(text::simple(&format!(
+                                    "{}",
+                                    ctx.converter.converts(*active_balance)
+                                ))))
+                                .push(text::simple(&ctx.converter.unit.to_string()))
+                                .spacing(10)
+                                .align_items(Align::Center),
+                        )
+                        .push(text::simple("are delegated to the managers")),
+                ))
+                .width(Length::Fill),
+            )
+            .push(
+                card::white(Container::new(
+                    Column::new()
+                        .push(vaults_header)
+                        .push(Column::with_children(vaults))
+                        .spacing(20),
+                ))
+                .width(Length::Fill),
+            )
+            .spacing(15);
+
+        layout::dashboard(
+            navbar(layout::navbar_warning(warning)),
+            self.sidebar.view(ctx),
+            layout::main_section(Container::new(Scrollable::new(&mut self.scroll).push(col))),
+        )
+        .into()
     }
 }

--- a/src/ui/view/vault.rs
+++ b/src/ui/view/vault.rs
@@ -464,7 +464,10 @@ impl DelegateVaultView {
                             .push(text::bold(text::simple("Delegate vault to manager")))
                             .push(text::simple("the unvault transaction must be signed in order to delegate the fund to the managers.")),
                     )
-                    .push(signer.map(|msg| Message::Vault(VaultMessage::Sign(msg))))
+                    .push(signer.map(move |msg| match msg {
+                        SignMessage::Clipboard(s) => Message::Clipboard(s),
+                        _ => Message::Vault(VaultMessage::Sign(msg)),
+                    }))
                     .spacing(20),
             )))
             .into()


### PR DESCRIPTION
first commit, add a delegate section to vault modal that a stakeholder can click on it and start signing unvault_tx
![2021-03-15T14:29:47,803352244+01:00](https://user-images.githubusercontent.com/6933020/111161168-1e514600-859b-11eb-8bdd-9fd76104a182.png)
![2021-03-15T14:29:30,002290116+01:00](https://user-images.githubusercontent.com/6933020/111161185-23ae9080-859b-11eb-9c08-a4da2ec9cfb1.png)
![2021-03-15T14:29:14,754271972+01:00](https://user-images.githubusercontent.com/6933020/111161204-29a47180-859b-11eb-828f-a763565a7326.png)
last commit add the delegate funds panel where the user can:
- see the amount delegated to managers
- see the available acknowledged vaults that can be delegated
- see the vaults delegated to managers
![2021-03-15T14:35:02,852507310+01:00](https://user-images.githubusercontent.com/6933020/111161830-d5e65800-859b-11eb-8612-4a14f4186421.png)
