### PR TITLE
fix(ui): set edit_role in context view

### DIFF
--- a/src/ui/view/sidebar.rs
+++ b/src/ui/view/sidebar.rs
@@ -52,7 +52,7 @@ impl Sidebar {
                 .style(TransparentPickListStyle),
             )
         } else {
-            Container::new(text::simple(&context.role.to_string()))
+            Container::new(text::simple(&context.role.to_string())).padding(10)
         };
         let home_button = if context.menu == Menu::Home {
             button::primary(


### PR DESCRIPTION
The user can not anymore edit the role in the sidebar
if the revaultd configuration does not specify both
the stakeholder and the manager configuration parts.

close #75
close #71 