### PR TITLE
fix ui: wrong home delegate-funds button message

### DIFF
--- a/src/ui/view/home.rs
+++ b/src/ui/view/home.rs
@@ -293,7 +293,7 @@ impl StakeholderOverview {
                             &mut self.delegate_fund_button,
                             button::button_content(Some(arrow_up_icon()), "Delegate funds"),
                         )
-                        .on_press(Message::Menu(Menu::ACKFunds)),
+                        .on_press(Message::Menu(Menu::DelegateFunds)),
                     )
                     .width(Length::Fill)
                     .align_x(Align::Center),


### PR DESCRIPTION
Stakeholde home overview displays a button to delegate funds
and the button was redirecting to acknowledge funds panel
instead of the delegate funds panel.

close #89