### PR TITLE
UI: refac history for vaults detail

### DIFF
--- a/src/revaultd/model.rs
+++ b/src/revaultd/model.rs
@@ -74,9 +74,12 @@ pub enum VaultStatus {
     /// One of the emergency transactions is confirmed
     #[serde(rename = "emergencyvaulted")]
     EmergencyVaulted,
-    /// The unvault transaction CSV is expired
-    #[serde(rename = "spendable")]
-    Spendable,
+    /// The unvault emergency transactions has been broadcast
+    #[serde(rename = "unvaultemergencyvaulting")]
+    UnvaultEmergencyVaulting,
+    /// The unvault emergency transactions is confirmed
+    #[serde(rename = "unvaultemergencyvaulted")]
+    UnvaultEmergencyVaulted,
     /// The spend transaction has been broadcast
     #[serde(rename = "spending")]
     Spending,
@@ -100,11 +103,53 @@ impl std::fmt::Display for VaultStatus {
             Self::Canceled => write!(f, "Canceled"),
             Self::EmergencyVaulting => write!(f, "Emergency vaulting"),
             Self::EmergencyVaulted => write!(f, "Emergency vaulted"),
-            Self::Spendable => write!(f, "Spendable"),
+            Self::UnvaultEmergencyVaulting => write!(f, "Unvault Emergency vaulting"),
+            Self::UnvaultEmergencyVaulted => write!(f, "Unvault Emergency vaulted"),
             Self::Spending => write!(f, "Spending"),
             Self::Spent => write!(f, "Spent"),
         }
     }
+}
+
+impl VaultStatus {
+    pub const CURRENT: [VaultStatus; 11] = [
+        Self::Funded,
+        Self::Securing,
+        Self::Secured,
+        Self::Activating,
+        Self::Active,
+        Self::Unvaulting,
+        Self::Unvaulted,
+        Self::Canceling,
+        Self::EmergencyVaulting,
+        Self::UnvaultEmergencyVaulting,
+        Self::Spending,
+    ];
+
+    pub const ACTIVE: [VaultStatus; 1] = [Self::Active];
+
+    pub const INACTIVE: [VaultStatus; 4] = [
+        Self::Funded,
+        Self::Securing,
+        Self::Secured,
+        Self::Activating,
+    ];
+
+    pub const MOVING: [VaultStatus; 6] = [
+        Self::Unvaulting,
+        Self::Unvaulted,
+        Self::Canceling,
+        Self::EmergencyVaulting,
+        Self::UnvaultEmergencyVaulting,
+        Self::Spending,
+    ];
+
+    pub const MOVED: [VaultStatus; 4] = [
+        Self::Canceled,
+        Self::EmergencyVaulted,
+        Self::UnvaultEmergencyVaulted,
+        Self::Spent,
+    ];
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -7,9 +7,9 @@ use iced::{executor, Application, Clipboard, Color, Command, Element, Settings, 
 use super::menu::Menu;
 use super::message::{Message, SignMessage, SpendTxMessage, VaultMessage};
 use super::state::{
-    ChargingState, DepositState, HistoryState, ManagerHomeState, ManagerNetworkState,
-    ManagerSendState, SettingsState, StakeholderACKFundsState, StakeholderDelegateFundsState,
-    StakeholderHomeState, StakeholderNetworkState, State,
+    ChargingState, DepositState, ManagerHomeState, ManagerNetworkState, ManagerSendState,
+    SettingsState, StakeholderACKFundsState, StakeholderDelegateFundsState, StakeholderHomeState,
+    StakeholderNetworkState, State, VaultsState,
 };
 
 use crate::{conversion::Converter, revault::Role, revaultd::RevaultD, ui::view::Context};
@@ -35,7 +35,7 @@ impl App {
             Role::Manager => match self.context.menu {
                 Menu::Deposit => DepositState::new(revaultd).into(),
                 Menu::Home => ManagerHomeState::new(revaultd).into(),
-                Menu::History => HistoryState::new(revaultd).into(),
+                Menu::Vaults => VaultsState::new(revaultd).into(),
                 Menu::Network => ManagerNetworkState::new(revaultd).into(),
                 Menu::Send => ManagerSendState::new(revaultd).into(),
                 // Manager cannot delegate funds, the user is redirected to the home.
@@ -46,7 +46,7 @@ impl App {
             Role::Stakeholder => match self.context.menu {
                 Menu::Deposit => DepositState::new(revaultd).into(),
                 Menu::Home => StakeholderHomeState::new(revaultd).into(),
-                Menu::History => HistoryState::new(revaultd).into(),
+                Menu::Vaults => VaultsState::new(revaultd).into(),
                 Menu::Network => StakeholderNetworkState::new(revaultd).into(),
                 Menu::ACKFunds => StakeholderACKFundsState::new(revaultd).into(),
                 Menu::DelegateFunds => StakeholderDelegateFundsState::new(revaultd).into(),

--- a/src/ui/component/icon.rs
+++ b/src/ui/component/icon.rs
@@ -34,8 +34,13 @@ pub fn turnback_icon() -> Text {
     icon('\u{F131}')
 }
 
+#[allow(dead_code)]
 pub fn history_icon() -> Text {
     icon('\u{F292}')
+}
+
+pub fn vaults_icon() -> Text {
+    icon('\u{F1C7}')
 }
 
 pub fn settings_icon() -> Text {

--- a/src/ui/menu.rs
+++ b/src/ui/menu.rs
@@ -2,10 +2,10 @@
 pub enum Menu {
     Deposit,
     Home,
-    History,
     Network,
     Send,
     ACKFunds,
     DelegateFunds,
     Settings,
+    Vaults,
 }

--- a/src/ui/message.rs
+++ b/src/ui/message.rs
@@ -78,7 +78,7 @@ pub enum VaultMessage {
 
 #[derive(Debug, Clone)]
 pub enum VaultFilterMessage {
-    Status(Vec<VaultStatus>),
+    Status(&'static [VaultStatus]),
 }
 
 #[derive(Debug, Clone)]

--- a/src/ui/state/mod.rs
+++ b/src/ui/state/mod.rs
@@ -1,19 +1,18 @@
 pub mod charging;
 mod cmd;
 mod deposit;
-mod history;
 pub mod manager;
 mod settings;
 mod sign;
 mod spend_transaction;
 pub mod stakeholder;
 mod vault;
+mod vaults;
 
 use iced::{Command, Element, Subscription};
 
 pub use charging::ChargingState;
 pub use deposit::DepositState;
-pub use history::HistoryState;
 pub use manager::{ManagerHomeState, ManagerNetworkState, ManagerSendState};
 pub use settings::SettingsState;
 pub use spend_transaction::{SpendTransactionListItem, SpendTransactionState};
@@ -21,6 +20,7 @@ pub use stakeholder::{
     StakeholderACKFundsState, StakeholderDelegateFundsState, StakeholderHomeState,
     StakeholderNetworkState,
 };
+pub use vaults::VaultsState;
 
 use super::{message::Message, view::Context};
 

--- a/src/ui/state/stakeholder.rs
+++ b/src/ui/state/stakeholder.rs
@@ -343,7 +343,7 @@ pub struct StakeholderDelegateFundsState {
     revaultd: Arc<RevaultD>,
 
     active_balance: u64,
-    vault_status_filter: Vec<VaultStatus>,
+    vault_status_filter: &'static [VaultStatus],
     vaults: Vec<VaultListItem<DelegateVaultListItemView>>,
     selected_vault: Option<Vault>,
     warning: Option<Error>,
@@ -357,12 +357,7 @@ impl StakeholderDelegateFundsState {
             revaultd,
             active_balance: 0,
             vaults: Vec::new(),
-            vault_status_filter: vec![
-                VaultStatus::Funded,
-                VaultStatus::Securing,
-                VaultStatus::Activating,
-                VaultStatus::Secured,
-            ],
+            vault_status_filter: &VaultStatus::INACTIVE,
             selected_vault: None,
             warning: None,
             view: StakeholderDelegateFundsView::new(),

--- a/src/ui/state/vaults.rs
+++ b/src/ui/state/vaults.rs
@@ -14,13 +14,13 @@ use crate::revaultd::{model, RevaultD};
 use crate::ui::{
     error::Error,
     message::{Message, VaultMessage},
-    view::{vault::VaultListItemView, Context, HistoryView},
+    view::{vault::VaultListItemView, Context, VaultsView},
 };
 
 #[derive(Debug)]
-pub struct HistoryState {
+pub struct VaultsState {
     revaultd: Arc<RevaultD>,
-    view: HistoryView,
+    view: VaultsView,
 
     blockheight: u64,
     warning: Option<Error>,
@@ -29,11 +29,11 @@ pub struct HistoryState {
     selected_vault: Option<Vault>,
 }
 
-impl HistoryState {
+impl VaultsState {
     pub fn new(revaultd: Arc<RevaultD>) -> Self {
-        HistoryState {
+        VaultsState {
             revaultd,
-            view: HistoryView::new(),
+            view: VaultsView::new(),
             blockheight: 0,
             vaults: Vec::new(),
             warning: None,
@@ -70,7 +70,7 @@ impl HistoryState {
     }
 }
 
-impl State for HistoryState {
+impl State for VaultsState {
     fn update(&mut self, message: Message) -> Command<Message> {
         match message {
             Message::Vaults(res) => match res {
@@ -117,8 +117,8 @@ impl State for HistoryState {
     }
 }
 
-impl From<HistoryState> for Box<dyn State> {
-    fn from(s: HistoryState) -> Box<dyn State> {
+impl From<VaultsState> for Box<dyn State> {
+    fn from(s: VaultsState) -> Box<dyn State> {
         Box::new(s)
     }
 }

--- a/src/ui/view/mod.rs
+++ b/src/ui/view/mod.rs
@@ -1,6 +1,5 @@
 pub mod charging;
 mod deposit;
-mod history;
 mod home;
 mod layout;
 pub mod manager;
@@ -11,15 +10,16 @@ pub mod sign;
 pub mod spend_transaction;
 pub mod stakeholder;
 pub mod vault;
+mod vaults;
 
 pub use deposit::DepositView;
-pub use history::HistoryView;
 pub use home::{ManagerHomeView, StakeholderHomeView};
 pub use network::{ManagerNetworkView, StakeholderNetworkView};
 pub use settings::SettingsView;
 pub use spend_transaction::{SpendTransactionListItemView, SpendTransactionView};
 pub use stakeholder::{StakeholderACKFundsView, StakeholderDelegateFundsView};
 pub use vault::VaultView;
+pub use vaults::VaultsView;
 
 use bitcoin::Network;
 

--- a/src/ui/view/sidebar.rs
+++ b/src/ui/view/sidebar.rs
@@ -5,8 +5,8 @@ use crate::ui::{
     component::{
         button,
         icon::{
-            deposit_icon, dot_icon, history_icon, home_icon, network_icon, person_check_icon,
-            send_icon, settings_icon,
+            deposit_icon, dot_icon, home_icon, network_icon, person_check_icon, send_icon,
+            settings_icon, vaults_icon,
         },
         separation, text, TransparentPickListStyle,
     },
@@ -21,7 +21,7 @@ pub struct Sidebar {
     deposit_menu_button: iced::button::State,
     delegate_menu_button: iced::button::State,
     home_menu_button: iced::button::State,
-    history_menu_button: iced::button::State,
+    vaults_menu_button: iced::button::State,
     network_menu_button: iced::button::State,
     spend_menu_button: iced::button::State,
     settings_menu_button: iced::button::State,
@@ -33,7 +33,7 @@ impl Sidebar {
             deposit_menu_button: iced::button::State::new(),
             delegate_menu_button: iced::button::State::new(),
             home_menu_button: iced::button::State::new(),
-            history_menu_button: iced::button::State::new(),
+            vaults_menu_button: iced::button::State::new(),
             network_menu_button: iced::button::State::new(),
             spend_menu_button: iced::button::State::new(),
             settings_menu_button: iced::button::State::new(),
@@ -70,18 +70,18 @@ impl Sidebar {
             )
             .on_press(Message::Menu(Menu::Home))
         };
-        let history_button = if context.menu == Menu::History {
+        let vaults_button = if context.menu == Menu::Vaults {
             button::primary(
-                &mut self.history_menu_button,
-                button::button_content(Some(history_icon()), "History"),
+                &mut self.vaults_menu_button,
+                button::button_content(Some(vaults_icon()), "Vaults"),
             )
-            .on_press(Message::Menu(Menu::History))
+            .on_press(Message::Menu(Menu::Vaults))
         } else {
             button::transparent(
-                &mut self.history_menu_button,
-                button::button_content(Some(history_icon()), "History"),
+                &mut self.vaults_menu_button,
+                button::button_content(Some(vaults_icon()), "Vaults"),
             )
-            .on_press(Message::Menu(Menu::History))
+            .on_press(Message::Menu(Menu::Vaults))
         };
         let network_button = if context.menu == Menu::Network {
             button::primary(
@@ -172,7 +172,7 @@ impl Sidebar {
                 role.width(Length::Units(200)),
                 separation().width(iced::Length::Units(200)),
                 Container::new(home_button.width(Length::Units(200))),
-                Container::new(history_button.width(Length::Units(200))),
+                Container::new(vaults_button.width(Length::Units(200))),
                 Container::new(network_button.width(Length::Units(200))),
                 separation().width(Length::Units(200)),
                 Container::new(deposit_button.width(Length::Units(200))),

--- a/src/ui/view/stakeholder.rs
+++ b/src/ui/view/stakeholder.rs
@@ -102,11 +102,7 @@ impl StakeholderDelegateFundsView {
                         button::button_content(None, "Available vaults"),
                     )
                     .on_press(Message::FilterVaults(
-                        VaultFilterMessage::Status(vec![
-                            VaultStatus::Funded,
-                            VaultStatus::Securing,
-                            VaultStatus::Secured,
-                        ]),
+                        VaultFilterMessage::Status(&VaultStatus::INACTIVE),
                     )),
                 )
                 .push(
@@ -115,11 +111,7 @@ impl StakeholderDelegateFundsView {
                         button::button_content(None, "Delegated vaults"),
                     )
                     .on_press(Message::FilterVaults(
-                        VaultFilterMessage::Status(vec![
-                            VaultStatus::Active,
-                            VaultStatus::Unvaulting,
-                            VaultStatus::Unvaulted,
-                        ]),
+                        VaultFilterMessage::Status(&VaultStatus::ACTIVE),
                     )),
                 );
         } else {
@@ -130,11 +122,7 @@ impl StakeholderDelegateFundsView {
                         button::button_content(None, "Available vaults"),
                     )
                     .on_press(Message::FilterVaults(
-                        VaultFilterMessage::Status(vec![
-                            VaultStatus::Funded,
-                            VaultStatus::Securing,
-                            VaultStatus::Secured,
-                        ]),
+                        VaultFilterMessage::Status(&VaultStatus::INACTIVE),
                     )),
                 )
                 .push(
@@ -143,11 +131,7 @@ impl StakeholderDelegateFundsView {
                         button::button_content(None, "Delegated vaults"),
                     )
                     .on_press(Message::FilterVaults(
-                        VaultFilterMessage::Status(vec![
-                            VaultStatus::Active,
-                            VaultStatus::Unvaulting,
-                            VaultStatus::Unvaulted,
-                        ]),
+                        VaultFilterMessage::Status(&VaultStatus::ACTIVE),
                     )),
                 );
         }

--- a/src/ui/view/vault.rs
+++ b/src/ui/view/vault.rs
@@ -400,9 +400,13 @@ fn vault_badge<'a, T: 'a>(vault: &Vault) -> Container<'a, T> {
         | VaultStatus::Activating
         | VaultStatus::Active => badge::tx_deposit(),
         VaultStatus::Unvaulting | VaultStatus::Unvaulted => badge::vault_unvaulting(),
-        VaultStatus::Canceling | VaultStatus::EmergencyVaulting => badge::vault_canceling(),
-        VaultStatus::Canceled | VaultStatus::EmergencyVaulted => badge::vault_canceled(),
-        VaultStatus::Spendable | VaultStatus::Spending => badge::vault_spending(),
+        VaultStatus::Canceling
+        | VaultStatus::EmergencyVaulting
+        | VaultStatus::UnvaultEmergencyVaulting => badge::vault_canceling(),
+        VaultStatus::Canceled
+        | VaultStatus::EmergencyVaulted
+        | VaultStatus::UnvaultEmergencyVaulted => badge::vault_canceled(),
+        VaultStatus::Spending => badge::vault_spending(),
         VaultStatus::Spent => badge::vault_spent(),
     }
 }

--- a/src/ui/view/vaults.rs
+++ b/src/ui/view/vaults.rs
@@ -8,14 +8,14 @@ use crate::ui::{
 };
 
 #[derive(Debug)]
-pub struct HistoryView {
+pub struct VaultsView {
     scroll: scrollable::State,
     sidebar: Sidebar,
 }
 
-impl HistoryView {
+impl VaultsView {
     pub fn new() -> Self {
-        HistoryView {
+        VaultsView {
             sidebar: Sidebar::new(),
             scroll: scrollable::State::new(),
         }

--- a/src/ui/view/vaults.rs
+++ b/src/ui/view/vaults.rs
@@ -1,7 +1,7 @@
-use iced::{scrollable, Column, Container, Element};
+use iced::{scrollable, Column, Container, Element, Row};
 
 use crate::ui::{
-    component::{navbar, scroll},
+    component::{navbar, scroll, text},
     error::Error,
     message::Message,
     view::{layout, sidebar::Sidebar, Context},
@@ -34,6 +34,11 @@ impl VaultsView {
                 &mut self.scroll,
                 Container::new(
                     Column::new()
+                        .push(
+                            Row::new()
+                                .push(text::bold(text::simple(&format!(" {}", vaults.len()))))
+                                .push(text::simple(" vaults")),
+                        )
                         .push(Column::with_children(vaults).spacing(5))
                         .spacing(20),
                 ),

--- a/src/ui/view/vaults.rs
+++ b/src/ui/view/vaults.rs
@@ -1,16 +1,65 @@
-use iced::{scrollable, Column, Container, Element, Row};
+use iced::{pick_list, scrollable, Align, Column, Container, Element, Length, Row};
 
-use crate::ui::{
-    component::{navbar, scroll, text},
-    error::Error,
-    message::Message,
-    view::{layout, sidebar::Sidebar, Context},
+use crate::{
+    revaultd::model::VaultStatus,
+    ui::{
+        component::{navbar, scroll, text, TransparentPickListStyle},
+        error::Error,
+        message::{Message, VaultFilterMessage},
+        view::{layout, sidebar::Sidebar, Context},
+    },
 };
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum VaultsFilter {
+    Current,
+    Moving,
+    Moved,
+}
+
+impl VaultsFilter {
+    pub const ALL: [VaultsFilter; 3] = [
+        VaultsFilter::Current,
+        VaultsFilter::Moving,
+        VaultsFilter::Moved,
+    ];
+
+    pub fn new(statuses: &[VaultStatus]) -> VaultsFilter {
+        if statuses == VaultStatus::MOVING {
+            return VaultsFilter::Moving;
+        } else if statuses == VaultStatus::MOVED {
+            return VaultsFilter::Moved;
+        } else {
+            return VaultsFilter::Current;
+        }
+    }
+
+    pub fn statuses(&self) -> &'static [VaultStatus] {
+        match self {
+            Self::Current => &VaultStatus::CURRENT,
+            Self::Moving => &VaultStatus::MOVING,
+            Self::Moved => &VaultStatus::MOVED,
+        }
+    }
+}
+
+impl std::fmt::Display for VaultsFilter {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::Current => write!(f, "Current"),
+            Self::Moving => write!(f, "Moving"),
+            Self::Moved => write!(f, "Moved"),
+        }
+    }
+}
+
+/// VaultsView renders a list of vaults filtered by the status filter.
+/// If the loading field is true, only the status pick_list component is displayed.
 #[derive(Debug)]
 pub struct VaultsView {
     scroll: scrollable::State,
     sidebar: Sidebar,
+    pick_filter: pick_list::State<VaultsFilter>,
 }
 
 impl VaultsView {
@@ -18,6 +67,7 @@ impl VaultsView {
         VaultsView {
             sidebar: Sidebar::new(),
             scroll: scrollable::State::new(),
+            pick_filter: pick_list::State::default(),
         }
     }
 
@@ -26,22 +76,69 @@ impl VaultsView {
         ctx: &Context,
         warning: Option<&Error>,
         vaults: Vec<Element<'a, Message>>,
+        vault_status_filter: &[VaultStatus],
+        loading: bool,
     ) -> Element<'a, Message> {
+        let mut col = Column::new();
+
+        if !loading {
+            col = col
+                .push(
+                    Row::new()
+                        .push(
+                            Container::new(
+                                Row::new()
+                                    .push(text::bold(text::simple(&format!(" {}", vaults.len()))))
+                                    .push(text::simple(" vaults")),
+                            )
+                            .width(Length::Fill),
+                        )
+                        .push(
+                            pick_list::PickList::new(
+                                &mut self.pick_filter,
+                                &VaultsFilter::ALL[..],
+                                Some(VaultsFilter::new(vault_status_filter)),
+                                |filter| {
+                                    Message::FilterVaults(VaultFilterMessage::Status(
+                                        filter.statuses(),
+                                    ))
+                                },
+                            )
+                            .text_size(15)
+                            .padding(10)
+                            .width(Length::Units(200))
+                            .style(TransparentPickListStyle),
+                        )
+                        .align_items(Align::Center),
+                )
+                .push(Column::with_children(vaults).spacing(5));
+        } else {
+            col = col.push(
+                Row::new()
+                    .push(Container::new(Row::new()).width(Length::Fill))
+                    .push(
+                        pick_list::PickList::new(
+                            &mut self.pick_filter,
+                            &VaultsFilter::ALL[..],
+                            Some(VaultsFilter::new(vault_status_filter)),
+                            |filter| {
+                                Message::FilterVaults(VaultFilterMessage::Status(filter.statuses()))
+                            },
+                        )
+                        .padding(10)
+                        .width(Length::Units(200))
+                        .style(TransparentPickListStyle),
+                    )
+                    .align_items(Align::Center),
+            );
+        }
+
         layout::dashboard(
             navbar(layout::navbar_warning(warning)),
             self.sidebar.view(ctx),
             layout::main_section(Container::new(scroll(
                 &mut self.scroll,
-                Container::new(
-                    Column::new()
-                        .push(
-                            Row::new()
-                                .push(text::bold(text::simple(&format!(" {}", vaults.len()))))
-                                .push(text::simple(" vaults")),
-                        )
-                        .push(Column::with_children(vaults).spacing(5))
-                        .spacing(20),
-                ),
+                Container::new(col.spacing(20)),
             ))),
         )
         .into()


### PR DESCRIPTION
History panel was not a time lined list of the wallet transactions, it was only a list of current and passed vaults.
For clarity the panel is renamed for Vaults

Vaults panel now has filter on the status, The filters are:

* current: all vaults with status different of Cancelled and Spent
* Not Delegated: all vaults with status: funded, securing, secured, activating
* Delegated: all vaults with status: active
* Moving: all vaults with status: unvaulting, unvaulted, spending, cancelling
* Passed or Moved: all vaults with status Cancelled and Spent

close #104