### PR TITLE
Use a config file to store ui config

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,13 @@
 Revault GUI is an user graphical interface written in rust for the 
 [Revault daemon](https:://github.com/revault/revaultd).
 
+## Usage
+
+`cargo run --release -- --conf revault_gui.toml`
+
+If no argument is provided, the GUI checks for the configuration file
+in the default revaultd datadir (`~/.revault` for linux).
+
 ## Get started
 
 See [doc/DEMO.md](doc/DEMO.md) for instructions on how to start the GUI
-
-## ENV vars:
-
-| Var                   | Description                                                                                                                                                              |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `REVAULTD_CONF`       | Path to the [revaultd](https://github.com/revault/revaultd) configuration path                                                                                          |
-| `REVAULTGUI_DEBUG`    | If `true`, the interface will use `iced` debug feature to display current layout and set log level to `debug`                                                            |
-| `REVAULTGUI_LOG`      | Enable the [tracing env filter](https://docs.rs/tracing-subscriber/0.2.15/tracing_subscriber/filter/struct.EnvFilter.html) example: `revault_gui::revault::client=debug` |
-| `REVAULTD_PATH`       | Path to the [revaultd](https://github.com/revault/revaultd) binary                                                                                                      |

--- a/contrib/revault_gui.toml
+++ b/contrib/revault_gui.toml
@@ -1,0 +1,10 @@
+# Revault GUI configuration file example.
+
+# Path to revaultd configuration file (required).
+revaultd_config_path = "path/to/revault.toml"
+# Path to revaultd binary (optional).
+revaultd_path = "path/to/revaultd/binary"
+# log level, can be "info", "debug", "trace" (optional).
+log_level = "trace"
+# Use iced debug feature if true (optional).
+debug = true

--- a/doc/DEMO.md
+++ b/doc/DEMO.md
@@ -42,21 +42,25 @@ Building the GUI...
 cargo build --release
 ```
 
-### 1. Providing the configuration
-Let's create some aliases:
+### 1. Create the configuration
+
 ```
-alias stake_1_gui="REVAULTD_CONF=\"../revaultd/stake_1_config.toml\" cargo run --release"
-alias stake_2_gui="REVAULTD_CONF=\"../revaultd/stake_2_config.toml\" cargo run --release"
-alias man_1_gui="REVAULTD_CONF=\"../revaultd/man_1_config.toml\" cargo run --release"
+cd ..
+echo "revaultd_config_path=$(pwd)/revaultd/stake_1_config.toml" > revault-gui/stake_1_config_ui.toml
+echo "revaultd_config_path=$(pwd)/revaultd/stake_2_config.toml" > revault-gui/stake_2_config_ui.toml
+echo "revaultd_config_path=$(pwd)/revaultd/stake_3_config.toml" > revault-gui/stake_3_config_ui.toml
+echo "revaultd_config_path=$(pwd)/revaultd/man_1_config.toml" > revault-gui/man_1_config_ui.toml
 ```
 
-### 2. Let the GUI start the binary (optional)
-If you don't want to start `revaultd` manually each time you run the config, you can set the `REVAULTD_PATH` environment variable.
-This will start `revaultd` **only**, you'll need to start yourself `coordinatord` and `cosignerd` anyways.
-Double check that the `revaultd` configuration has `daemon=true`, otherwise the gui won't be able to start.
-Then:
+### 2. Providing the configuration
+
+Let's create some aliases:
 ```
-export REVAULTD_PATH="../revaultd/target/debug/revaultd"
+cd ./revault-gui
+alias stake_1_gui=cargo run --release -- --conf stake_1_config_ui.toml"
+alias stake_2_gui=cargo run --release -- --conf stake_2_config_ui.toml"
+alias stake_3_gui=cargo run --release -- --conf stake_3_config_ui.toml"
+alias man_1_gui="cargo run --release -- --conf  man_1_config_ui.toml"
 ```
 
 ### 3. Starting the GUI

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -1,5 +1,3 @@
-use std::fmt::Debug;
-use std::path::PathBuf;
 use std::sync::Arc;
 
 use iced::{executor, Application, Clipboard, Color, Command, Element, Settings, Subscription};
@@ -12,7 +10,12 @@ use super::state::{
     StakeholderNetworkState, State, VaultsState,
 };
 
-use crate::{conversion::Converter, revault::Role, revaultd::RevaultD, ui::view::Context};
+use crate::{
+    conversion::Converter,
+    revault::Role,
+    revaultd::RevaultD,
+    ui::{config::Config, view::Context},
+};
 
 pub struct App {
     config: Config,
@@ -134,17 +137,10 @@ impl Application for App {
 
     fn view(&mut self) -> Element<Self::Message> {
         let content = self.state.view(&self.context);
-        if self.config.debug {
+        if let Some(true) = self.config.debug {
             return content.explain(Color::BLACK);
         }
 
         content
     }
-}
-
-#[derive(Debug, Clone)]
-pub struct Config {
-    pub revaultd_config_path: Option<PathBuf>,
-    pub revaultd_path: Option<PathBuf>,
-    pub debug: bool,
 }

--- a/src/ui/config.rs
+++ b/src/ui/config.rs
@@ -1,0 +1,59 @@
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+
+use crate::revaultd::config::default_datadir;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Config {
+    /// Path to revaultd configuration file.
+    pub revaultd_config_path: PathBuf,
+    /// Path to revaultd binary.
+    pub revaultd_path: Option<PathBuf>,
+    /// log level, can be "info", "debug", "trace".
+    pub log_level: Option<String>,
+    /// Use iced debug feature if true.
+    pub debug: Option<bool>,
+}
+
+impl Config {
+    pub fn from_file(path: &Path) -> Result<Self, ConfigError> {
+        let config = std::fs::read(path)
+            .map_err(|e| match e.kind() {
+                std::io::ErrorKind::NotFound => ConfigError::NotFound,
+                _ => ConfigError::ReadingFile(format!("Reading configuration file: {}", e)),
+            })
+            .and_then(|file_content| {
+                toml::from_slice::<Config>(&file_content).map_err(|e| {
+                    ConfigError::ReadingFile(format!("Parsing configuration file: {}", e))
+                })
+            })?;
+        Ok(config)
+    }
+
+    pub fn default_path() -> Result<PathBuf, ConfigError> {
+        let mut datadir = default_datadir().map_err(|_| {
+            ConfigError::Unexpected("Could not locate the default datadir directory.".to_owned())
+        })?;
+        datadir.push("revault_gui.toml");
+        Ok(datadir)
+    }
+}
+
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub enum ConfigError {
+    NotFound,
+    ReadingFile(String),
+    Unexpected(String),
+}
+
+impl std::fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::NotFound => write!(f, "Config file not found"),
+            Self::ReadingFile(e) => write!(f, "Error while reading file: {}", e),
+            Self::Unexpected(e) => write!(f, "Unexpected error: {}", e),
+        }
+    }
+}
+
+impl std::error::Error for ConfigError {}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,5 +1,6 @@
 pub mod app;
 mod component;
+pub mod config;
 mod error;
 mod menu;
 mod message;

--- a/src/ui/view/charging.rs
+++ b/src/ui/view/charging.rs
@@ -1,4 +1,4 @@
-use iced::{button, Container, Element};
+use iced::Element;
 
 use crate::ui::{component, message::Message, view::layout};
 
@@ -19,21 +19,4 @@ pub fn charging_syncing_view(progress: &f64) -> Element<'static, Message> {
 
 pub fn charging_error_view(error: &str) -> Element<'static, Message> {
     layout::cover(component::text::paragraph(&format!("Error: {}", error)))
-}
-
-#[derive(Debug, Clone)]
-pub struct ChargingAskInstallView {
-    validate_button: button::State,
-}
-
-impl ChargingAskInstallView {
-    pub fn new() -> ChargingAskInstallView {
-        Self {
-            validate_button: button::State::new(),
-        }
-    }
-    pub fn view(&mut self) -> Element<Message> {
-        let text = component::text::paragraph("No config found");
-        layout::cover(Container::new(text))
-    }
 }


### PR DESCRIPTION
Remove env var for a config file passed with `--conf` flag
revaultd_config_path is not optional in the config