### PR TITLE
Feat installer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,8 +137,19 @@ dependencies = [
  "base64-compat",
  "bech32",
  "bitcoin_hashes",
- "secp256k1",
+ "secp256k1 0.19.0",
  "serde",
+]
+
+[[package]]
+name = "bitcoin"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec5f88a446d66e7474a3b8fa2e348320b574463fb78d799d90ba68f79f48e0e"
+dependencies = [
+ "bech32",
+ "bitcoin_hashes",
+ "secp256k1 0.20.2",
 ]
 
 [[package]]
@@ -148,6 +159,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0aaf87b776808e26ae93289bc7d025092b6d909c193f0cdee0b3a86e7bd3c776"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bitcoinconsensus"
+version = "0.19.0-3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a8aa43b5cd02f856cb126a9af819e77b8910fdd74dd1407be649f2f5fe3a1b5"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -1724,6 +1745,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniscript"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71f455be59a359d50370c4f587afbc5739c862e684c5afecae80ab93e7474b4e"
+dependencies = [
+ "bitcoin 0.26.0",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2333,16 +2363,29 @@ dependencies = [
 name = "revault-gui"
 version = "0.0.1"
 dependencies = [
- "bitcoin",
+ "bitcoin 0.25.2",
  "chrono",
  "dirs 3.0.1",
  "iced",
+ "miniscript",
+ "revault_tx",
  "serde",
  "serde_json",
  "toml",
  "tracing",
  "tracing-subscriber",
  "uds_windows",
+]
+
+[[package]]
+name = "revault_tx"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05cb1531ea70874181c5cc8af3b3a4c1493e53f495fc479306bd2834fa7a027"
+dependencies = [
+ "base64",
+ "bitcoinconsensus",
+ "miniscript",
 ]
 
 [[package]]
@@ -2458,8 +2501,17 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6179428c22c73ac0fbb7b5579a56353ce78ba29759b3b8575183336ea74cdfb"
 dependencies = [
- "secp256k1-sys",
+ "secp256k1-sys 0.3.0",
  "serde",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee5070fdc6f26ca5be6dcfc3d07c76fdb974a63a8b246b459854274145f5a258"
+dependencies = [
+ "secp256k1-sys 0.4.0",
 ]
 
 [[package]]
@@ -2467,6 +2519,15 @@ name = "secp256k1-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11553d210db090930f4432bea123b31f70bbf693ace14504ea2a35e796c28dd2"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67e4b6455ee49f5901c8985b88f98fb0a0e1d90a6661f5a03f4888bd987dad29"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ edition = "2018"
 
 [dependencies]
 bitcoin = { version = "0.25.2", features = ["base64", "use-serde"] }
+revault_tx = "0.2.1"
+miniscript = "5.1.0"
 
 iced = { version = "0.3", features = ["wgpu", "svg", "debug", "qr_code"] }
 

--- a/README.md
+++ b/README.md
@@ -5,10 +5,17 @@ Revault GUI is an user graphical interface written in rust for the
 
 ## Usage
 
-`cargo run --release -- --conf revault_gui.toml`
+`cargo run --release -- --conf revault_gui.toml` or
+`cargo run --release -- --datadir revault`
 
 If no argument is provided, the GUI checks for the configuration file
-in the default revaultd datadir (`~/.revault` for linux).
+in the default revaultd `datadir` (`~/.revault` for linux).
+
+If the provided `datadir` is empty or does not exist, the GUI starts with
+the installer mode.
+
+After start up, The GUI will connect to the running revaultd.
+A command starting revaultd is launched if no connection is made.
 
 ## Get started
 

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -1,9 +1,9 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
 use crate::revaultd::config::default_datadir;
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Config {
     /// Path to revaultd configuration file.
     pub revaultd_config_path: PathBuf,
@@ -18,6 +18,15 @@ pub struct Config {
 pub const DEFAULT_FILE_NAME: &'static str = "revault_gui.toml";
 
 impl Config {
+    pub fn new(revaultd_config_path: PathBuf) -> Self {
+        Self {
+            revaultd_config_path,
+            revaultd_path: None,
+            log_level: None,
+            debug: None,
+        }
+    }
+
     pub fn from_file(path: &Path) -> Result<Self, ConfigError> {
         let config = std::fs::read(path)
             .map_err(|e| match e.kind() {

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -15,6 +15,8 @@ pub struct Config {
     pub debug: Option<bool>,
 }
 
+pub const DEFAULT_FILE_NAME: &'static str = "revault_gui.toml";
+
 impl Config {
     pub fn from_file(path: &Path) -> Result<Self, ConfigError> {
         let config = std::fs::read(path)
@@ -34,7 +36,7 @@ impl Config {
         let mut datadir = default_datadir().map_err(|_| {
             ConfigError::Unexpected("Could not locate the default datadir directory.".to_owned())
         })?;
-        datadir.push("revault_gui.toml");
+        datadir.push(DEFAULT_FILE_NAME);
         Ok(datadir)
     }
 }

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -15,7 +15,7 @@ pub struct Config {
     pub debug: Option<bool>,
 }
 
-pub const DEFAULT_FILE_NAME: &'static str = "revault_gui.toml";
+pub const DEFAULT_FILE_NAME: &str = "revault_gui.toml";
 
 impl Config {
     pub fn new(revaultd_config_path: PathBuf) -> Self {

--- a/src/installer/message.rs
+++ b/src/installer/message.rs
@@ -18,11 +18,19 @@ pub enum DefineStakeholderXpubs {
 
 #[derive(Debug, Clone)]
 pub enum DefineManagerXpubs {
+    ManagersTreshold(Action),
+    SpendingDelay(Action),
     OurXpubEdited(String),
     ManagerXpub(usize, ParticipantXpub),
     CosignerKey(usize, CosignerKey),
     AddXpub,
     AddCosigner,
+}
+
+#[derive(Debug, Clone)]
+pub enum Action {
+    Increment,
+    Decrement,
 }
 
 #[derive(Debug, Clone)]

--- a/src/installer/message.rs
+++ b/src/installer/message.rs
@@ -1,13 +1,15 @@
+use std::path::PathBuf;
+
 use super::Error;
 use crate::revault::Role;
 
 #[derive(Debug, Clone)]
 pub enum Message {
-    Exit,
+    Exit(PathBuf),
     Next,
     Previous,
     Install,
-    Installed(Result<(), Error>),
+    Installed(Result<PathBuf, Error>),
     Role(&'static [Role]),
     DefineStakeholderXpubs(DefineStakeholderXpubs),
     DefineManagerXpubs(DefineManagerXpubs),

--- a/src/installer/message.rs
+++ b/src/installer/message.rs
@@ -12,11 +12,11 @@ pub enum Message {
     DefineEmergencyAddress(String),
     DefineWatchtowers(DefineWatchtowers),
     DefineCosigners(usize, DefineCosigner),
-    DefineBitcoind(Bitcoind),
+    DefineBitcoind(DefineBitcoind),
 }
 
 #[derive(Debug, Clone)]
-pub enum Bitcoind {
+pub enum DefineBitcoind {
     CookiePathEdited(String),
     AddressEdited(String),
 }

--- a/src/installer/message.rs
+++ b/src/installer/message.rs
@@ -72,9 +72,8 @@ pub enum DefineManagerXpubs {
     SpendingDelay(Action),
     OurXpubEdited(String),
     ManagerXpub(usize, ParticipantXpub),
-    CosignerKey(usize, CosignerKey),
+    CosignerKey(usize, String),
     AddXpub,
-    AddCosigner,
 }
 
 #[derive(Debug, Clone)]
@@ -87,10 +86,4 @@ pub enum Action {
 pub enum ParticipantXpub {
     Delete,
     XpubEdited(String),
-}
-
-#[derive(Debug, Clone)]
-pub enum CosignerKey {
-    Delete,
-    KeyEdited(String),
 }

--- a/src/installer/message.rs
+++ b/src/installer/message.rs
@@ -3,6 +3,7 @@ use crate::revault::Role;
 
 #[derive(Debug, Clone)]
 pub enum Message {
+    Exit,
     Next,
     Previous,
     Install,

--- a/src/installer/message.rs
+++ b/src/installer/message.rs
@@ -55,8 +55,7 @@ pub enum DefineCoordinator {
 
 #[derive(Debug, Clone)]
 pub enum DefineCpfpDescriptor {
-    ManagerXpub(usize, ParticipantXpub),
-    AddXpub,
+    ManagerXpub(usize, String),
 }
 
 #[derive(Debug, Clone)]

--- a/src/installer/message.rs
+++ b/src/installer/message.rs
@@ -1,9 +1,12 @@
+use super::Error;
 use crate::revault::Role;
 
 #[derive(Debug, Clone)]
 pub enum Message {
     Next,
     Previous,
+    Install,
+    Installed(Result<(), Error>),
     Role(&'static [Role]),
     DefineStakeholderXpubs(DefineStakeholderXpubs),
     DefineManagerXpubs(DefineManagerXpubs),

--- a/src/installer/message.rs
+++ b/src/installer/message.rs
@@ -7,6 +7,13 @@ pub enum Message {
     Role(&'static [Role]),
     DefineStakeholderXpubs(DefineStakeholderXpubs),
     DefineManagerXpubs(DefineManagerXpubs),
+    DefineCpfpDescriptor(DefineCpfpDescriptor),
+}
+
+#[derive(Debug, Clone)]
+pub enum DefineCpfpDescriptor {
+    ManagerXpub(usize, ParticipantXpub),
+    AddXpub,
 }
 
 #[derive(Debug, Clone)]

--- a/src/installer/message.rs
+++ b/src/installer/message.rs
@@ -8,6 +8,13 @@ pub enum Message {
     DefineStakeholderXpubs(DefineStakeholderXpubs),
     DefineManagerXpubs(DefineManagerXpubs),
     DefineCpfpDescriptor(DefineCpfpDescriptor),
+    DefineCoordinator(DefineCoordinator),
+}
+
+#[derive(Debug, Clone)]
+pub enum DefineCoordinator {
+    HostEdited(String),
+    NoiseKeyEdited(String),
 }
 
 #[derive(Debug, Clone)]

--- a/src/installer/message.rs
+++ b/src/installer/message.rs
@@ -21,6 +21,7 @@ pub enum Message {
 
 #[derive(Debug, Clone)]
 pub enum DefineBitcoind {
+    NetworkEdited(bitcoin::Network),
     CookiePathEdited(String),
     AddressEdited(String),
 }

--- a/src/installer/message.rs
+++ b/src/installer/message.rs
@@ -9,6 +9,7 @@ pub enum Message {
     DefineManagerXpubs(DefineManagerXpubs),
     DefineCpfpDescriptor(DefineCpfpDescriptor),
     DefineCoordinator(DefineCoordinator),
+    DefineEmergencyAddress(String),
 }
 
 #[derive(Debug, Clone)]

--- a/src/installer/message.rs
+++ b/src/installer/message.rs
@@ -11,6 +11,20 @@ pub enum Message {
     DefineCoordinator(DefineCoordinator),
     DefineEmergencyAddress(String),
     DefineWatchtowers(DefineWatchtowers),
+    DefineCosigners(usize, DefineCosigner),
+    DefineBitcoind(Bitcoind),
+}
+
+#[derive(Debug, Clone)]
+pub enum Bitcoind {
+    CookiePathEdited(String),
+    AddressEdited(String),
+}
+
+#[derive(Debug, Clone)]
+pub enum DefineCosigner {
+    HostEdited(String),
+    NoiseKeyEdited(String),
 }
 
 #[derive(Debug, Clone)]

--- a/src/installer/message.rs
+++ b/src/installer/message.rs
@@ -68,7 +68,7 @@ pub enum DefineStakeholderXpubs {
 
 #[derive(Debug, Clone)]
 pub enum DefineManagerXpubs {
-    ManagersTreshold(Action),
+    ManagersThreshold(Action),
     SpendingDelay(Action),
     OurXpubEdited(String),
     ManagerXpub(usize, ParticipantXpub),

--- a/src/installer/message.rs
+++ b/src/installer/message.rs
@@ -1,0 +1,38 @@
+use crate::revault::Role;
+
+#[derive(Debug, Clone)]
+pub enum Message {
+    Next,
+    Previous,
+    Role(&'static [Role]),
+    DefineStakeholderXpubs(DefineStakeholderXpubs),
+    DefineManagerXpubs(DefineManagerXpubs),
+}
+
+#[derive(Debug, Clone)]
+pub enum DefineStakeholderXpubs {
+    OurXpubEdited(String),
+    StakeholderXpub(usize, ParticipantXpub),
+    AddXpub,
+}
+
+#[derive(Debug, Clone)]
+pub enum DefineManagerXpubs {
+    OurXpubEdited(String),
+    ManagerXpub(usize, ParticipantXpub),
+    CosignerKey(usize, CosignerKey),
+    AddXpub,
+    AddCosigner,
+}
+
+#[derive(Debug, Clone)]
+pub enum ParticipantXpub {
+    Delete,
+    XpubEdited(String),
+}
+
+#[derive(Debug, Clone)]
+pub enum CosignerKey {
+    Delete,
+    KeyEdited(String),
+}

--- a/src/installer/message.rs
+++ b/src/installer/message.rs
@@ -10,6 +10,20 @@ pub enum Message {
     DefineCpfpDescriptor(DefineCpfpDescriptor),
     DefineCoordinator(DefineCoordinator),
     DefineEmergencyAddress(String),
+    DefineWatchtowers(DefineWatchtowers),
+}
+
+#[derive(Debug, Clone)]
+pub enum DefineWatchtowers {
+    EditWatchtower(usize, DefineWatchtower),
+    AddWatchtower,
+}
+
+#[derive(Debug, Clone)]
+pub enum DefineWatchtower {
+    HostEdited(String),
+    NoiseKeyEdited(String),
+    Delete,
 }
 
 #[derive(Debug, Clone)]

--- a/src/installer/message.rs
+++ b/src/installer/message.rs
@@ -11,6 +11,7 @@ pub enum Message {
     Install,
     Installed(Result<PathBuf, Error>),
     Role(&'static [Role]),
+    PrivateNoiseKey(String),
     DefineStakeholderXpubs(DefineStakeholderXpubs),
     DefineManagerXpubs(DefineManagerXpubs),
     DefineCpfpDescriptor(DefineCpfpDescriptor),

--- a/src/installer/mod.rs
+++ b/src/installer/mod.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 
 use crate::revault::Role;
 use message::Message;
-use step::{manager, stakeholder, DefineRole, Step, Welcome};
+use step::{manager, stakeholder, DefineCpfpDescriptor, DefineRole, Step, Welcome};
 
 pub fn run(config_path: PathBuf) -> Result<(), iced::Error> {
     Installer::run(Settings::with_flags(config_path))
@@ -42,6 +42,7 @@ impl Installer {
                 DefineRole::new().into(),
                 manager::DefineStakeholderXpubs::new().into(),
                 manager::DefineManagerXpubs::new().into(),
+                DefineCpfpDescriptor::new().into(),
             ];
         } else if role == Role::STAKEHOLDER_ONLY {
             self.steps = vec![
@@ -49,6 +50,7 @@ impl Installer {
                 DefineRole::new().into(),
                 stakeholder::DefineStakeholderXpubs::new().into(),
                 stakeholder::DefineManagerXpubs::new().into(),
+                DefineCpfpDescriptor::new().into(),
             ];
         } else {
             self.steps = vec![
@@ -56,6 +58,7 @@ impl Installer {
                 DefineRole::new().into(),
                 stakeholder::DefineStakeholderXpubs::new().into(),
                 manager::DefineManagerXpubs::new().into(),
+                DefineCpfpDescriptor::new().into(),
             ];
         }
     }

--- a/src/installer/mod.rs
+++ b/src/installer/mod.rs
@@ -153,10 +153,15 @@ impl Application for Installer {
             }
             Message::Install => {
                 self.current_step().update(message);
+
                 let mut cfg = revaultd_config::Config::new();
+                cfg.data_dir = Some(self.destination_path.clone());
+                cfg.daemon = Some(true);
+
                 for step in &self.steps {
                     step.edit_config(&mut cfg);
                 }
+
                 return Command::perform(
                     install(cfg, self.destination_path.clone()),
                     Message::Installed,

--- a/src/installer/mod.rs
+++ b/src/installer/mod.rs
@@ -199,7 +199,7 @@ pub async fn install(cfg: revaultd_config::Config, datadir_path: PathBuf) -> Res
 
     // create revault GUI configuration file
     let cfg = gui_config::Config::new(revaultd_config_path);
-    let mut gui_config_path = datadir_path.clone();
+    let mut gui_config_path = datadir_path;
     gui_config_path.push(gui_config::DEFAULT_FILE_NAME);
 
     let mut gui_config_file = std::fs::File::create(gui_config_path)

--- a/src/installer/mod.rs
+++ b/src/installer/mod.rs
@@ -1,0 +1,124 @@
+mod message;
+mod step;
+mod view;
+
+use iced::{executor, Application, Clipboard, Command, Element, Settings};
+
+use std::path::PathBuf;
+
+use crate::revault::Role;
+use message::Message;
+use step::{manager, stakeholder, DefineRole, Step, Welcome};
+
+pub fn run(config_path: PathBuf) -> Result<(), iced::Error> {
+    Installer::run(Settings::with_flags(config_path))
+}
+
+pub struct Installer {
+    destination_path: PathBuf,
+    exit: bool,
+
+    current: usize,
+    steps: Vec<Box<dyn Step>>,
+}
+
+impl Installer {
+    fn next(&mut self) {
+        if self.current < self.steps.len() - 1 {
+            self.current += 1;
+        }
+    }
+
+    fn previous(&mut self) {
+        if self.current > 0 {
+            self.current -= 1;
+        }
+    }
+
+    fn update_steps(&mut self, role: &[Role]) {
+        if role == Role::MANAGER_ONLY {
+            self.steps = vec![
+                Welcome::new().into(),
+                DefineRole::new().into(),
+                manager::DefineStakeholderXpubs::new().into(),
+                manager::DefineManagerXpubs::new().into(),
+            ];
+        } else if role == Role::STAKEHOLDER_ONLY {
+            self.steps = vec![
+                Welcome::new().into(),
+                DefineRole::new().into(),
+                stakeholder::DefineStakeholderXpubs::new().into(),
+                stakeholder::DefineManagerXpubs::new().into(),
+            ];
+        } else {
+            self.steps = vec![
+                Welcome::new().into(),
+                DefineRole::new().into(),
+                stakeholder::DefineStakeholderXpubs::new().into(),
+                manager::DefineManagerXpubs::new().into(),
+            ];
+        }
+    }
+
+    fn current_step(&mut self) -> &mut Box<dyn Step> {
+        self.steps
+            .get_mut(self.current)
+            .expect("There is always a step")
+    }
+}
+
+impl Application for Installer {
+    type Executor = executor::Default;
+    type Message = Message;
+    type Flags = PathBuf;
+
+    fn new(destination_path: PathBuf) -> (Installer, Command<Self::Message>) {
+        (
+            Installer {
+                destination_path,
+                exit: false,
+                current: 0,
+                steps: vec![Welcome::new().into(), DefineRole::new().into()],
+            },
+            Command::none(),
+        )
+    }
+
+    fn title(&self) -> String {
+        String::from("Revault Installer")
+    }
+
+    fn should_exit(&self) -> bool {
+        self.exit
+    }
+
+    fn update(
+        &mut self,
+        message: Self::Message,
+        _clipboard: &mut Clipboard,
+    ) -> Command<Self::Message> {
+        match message {
+            Message::Next => {
+                self.current_step().check();
+                if self.current_step().is_correct() {
+                    self.next();
+                }
+            }
+            Message::Previous => {
+                self.previous();
+            }
+            Message::Role(role) => {
+                self.update_steps(role);
+                self.next();
+            }
+            _ => {
+                self.current_step().update(message);
+            }
+        };
+        Command::none()
+    }
+
+    fn view(&mut self) -> Element<Self::Message> {
+        self.current_step().view()
+    }
+}

--- a/src/installer/mod.rs
+++ b/src/installer/mod.rs
@@ -90,7 +90,7 @@ impl Installer {
 
     pub fn new(destination_path: PathBuf) -> (Installer, Command<Message>) {
         let mut config = revaultd_config::Config::new();
-        config.data_dir = Some(destination_path.clone());
+        config.data_dir = Some(destination_path);
         config.daemon = Some(true);
         (
             Installer {

--- a/src/installer/mod.rs
+++ b/src/installer/mod.rs
@@ -60,8 +60,8 @@ impl Installer {
                 stakeholder::DefineManagerXpubs::new().into(),
                 DefineCpfpDescriptor::new().into(),
                 DefineCoordinator::new().into(),
-                stakeholder::DefineEmergencyAddress::new().into(),
                 DefineBitcoind::new().into(),
+                stakeholder::DefineEmergencyAddress::new().into(),
                 Final::new().into(),
             ];
         } else {
@@ -73,10 +73,10 @@ impl Installer {
                 manager::DefineManagerXpubs::new().into(),
                 DefineCpfpDescriptor::new().into(),
                 DefineCoordinator::new().into(),
-                stakeholder::DefineEmergencyAddress::new().into(),
                 stakeholder::DefineWatchtowers::new().into(),
                 manager::DefineCosigners::new().into(),
                 DefineBitcoind::new().into(),
+                stakeholder::DefineEmergencyAddress::new().into(),
                 Final::new().into(),
             ];
         }

--- a/src/installer/mod.rs
+++ b/src/installer/mod.rs
@@ -124,6 +124,9 @@ impl Application for Installer {
         _clipboard: &mut Clipboard,
     ) -> Command<Self::Message> {
         match message {
+            Message::Exit => {
+                self.exit = true;
+            }
             Message::Next => {
                 let current_step = self
                     .steps

--- a/src/installer/mod.rs
+++ b/src/installer/mod.rs
@@ -66,6 +66,7 @@ impl Installer {
                 DefineCpfpDescriptor::new().into(),
                 DefineCoordinator::new().into(),
                 stakeholder::DefineEmergencyAddress::new().into(),
+                stakeholder::DefineWatchtowers::new().into(),
             ];
         }
     }

--- a/src/installer/mod.rs
+++ b/src/installer/mod.rs
@@ -9,8 +9,8 @@ use std::path::PathBuf;
 use crate::revault::Role;
 use message::Message;
 use step::{
-    manager, stakeholder, Context, DefineCoordinator, DefineCpfpDescriptor, DefineRole, Step,
-    Welcome,
+    manager, stakeholder, Context, DefineBitcoind, DefineCoordinator, DefineCpfpDescriptor,
+    DefineRole, Step, Welcome,
 };
 
 pub fn run(config_path: PathBuf) -> Result<(), iced::Error> {
@@ -51,6 +51,7 @@ impl Installer {
                 DefineCpfpDescriptor::new().into(),
                 DefineCoordinator::new().into(),
                 manager::DefineCosigners::new().into(),
+                DefineBitcoind::new().into(),
             ];
         } else if role == Role::STAKEHOLDER_ONLY {
             self.steps = vec![
@@ -61,6 +62,7 @@ impl Installer {
                 DefineCpfpDescriptor::new().into(),
                 DefineCoordinator::new().into(),
                 stakeholder::DefineEmergencyAddress::new().into(),
+                DefineBitcoind::new().into(),
             ];
         } else {
             self.steps = vec![
@@ -73,6 +75,7 @@ impl Installer {
                 stakeholder::DefineEmergencyAddress::new().into(),
                 stakeholder::DefineWatchtowers::new().into(),
                 manager::DefineCosigners::new().into(),
+                DefineBitcoind::new().into(),
             ];
         }
     }

--- a/src/installer/mod.rs
+++ b/src/installer/mod.rs
@@ -55,6 +55,7 @@ impl Installer {
                 stakeholder::DefineManagerXpubs::new().into(),
                 DefineCpfpDescriptor::new().into(),
                 DefineCoordinator::new().into(),
+                stakeholder::DefineEmergencyAddress::new().into(),
             ];
         } else {
             self.steps = vec![
@@ -64,6 +65,7 @@ impl Installer {
                 manager::DefineManagerXpubs::new().into(),
                 DefineCpfpDescriptor::new().into(),
                 DefineCoordinator::new().into(),
+                stakeholder::DefineEmergencyAddress::new().into(),
             ];
         }
     }

--- a/src/installer/mod.rs
+++ b/src/installer/mod.rs
@@ -8,7 +8,9 @@ use std::path::PathBuf;
 
 use crate::revault::Role;
 use message::Message;
-use step::{manager, stakeholder, DefineCpfpDescriptor, DefineRole, Step, Welcome};
+use step::{
+    manager, stakeholder, DefineCoordinator, DefineCpfpDescriptor, DefineRole, Step, Welcome,
+};
 
 pub fn run(config_path: PathBuf) -> Result<(), iced::Error> {
     Installer::run(Settings::with_flags(config_path))
@@ -43,6 +45,7 @@ impl Installer {
                 manager::DefineStakeholderXpubs::new().into(),
                 manager::DefineManagerXpubs::new().into(),
                 DefineCpfpDescriptor::new().into(),
+                DefineCoordinator::new().into(),
             ];
         } else if role == Role::STAKEHOLDER_ONLY {
             self.steps = vec![
@@ -51,6 +54,7 @@ impl Installer {
                 stakeholder::DefineStakeholderXpubs::new().into(),
                 stakeholder::DefineManagerXpubs::new().into(),
                 DefineCpfpDescriptor::new().into(),
+                DefineCoordinator::new().into(),
             ];
         } else {
             self.steps = vec![
@@ -59,6 +63,7 @@ impl Installer {
                 stakeholder::DefineStakeholderXpubs::new().into(),
                 manager::DefineManagerXpubs::new().into(),
                 DefineCpfpDescriptor::new().into(),
+                DefineCoordinator::new().into(),
             ];
         }
     }

--- a/src/installer/mod.rs
+++ b/src/installer/mod.rs
@@ -10,7 +10,7 @@ use crate::revault::Role;
 use message::Message;
 use step::{
     manager, stakeholder, Context, DefineBitcoind, DefineCoordinator, DefineCpfpDescriptor,
-    DefineRole, Step, Welcome,
+    DefineRole, Final, Step, Welcome,
 };
 
 pub fn run(config_path: PathBuf) -> Result<(), iced::Error> {
@@ -52,6 +52,7 @@ impl Installer {
                 DefineCoordinator::new().into(),
                 manager::DefineCosigners::new().into(),
                 DefineBitcoind::new().into(),
+                Final::new().into(),
             ];
         } else if role == Role::STAKEHOLDER_ONLY {
             self.steps = vec![
@@ -63,6 +64,7 @@ impl Installer {
                 DefineCoordinator::new().into(),
                 stakeholder::DefineEmergencyAddress::new().into(),
                 DefineBitcoind::new().into(),
+                Final::new().into(),
             ];
         } else {
             self.steps = vec![
@@ -76,6 +78,7 @@ impl Installer {
                 stakeholder::DefineWatchtowers::new().into(),
                 manager::DefineCosigners::new().into(),
                 DefineBitcoind::new().into(),
+                Final::new().into(),
             ];
         }
     }
@@ -152,5 +155,20 @@ impl Application for Installer {
 
     fn view(&mut self) -> Element<Self::Message> {
         self.current_step().view()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum Error {
+    CannotCreateFile(String),
+    CannotWriteToFile(String),
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::CannotWriteToFile(e) => write!(f, "Failed to write to file: {}", e),
+            Self::CannotCreateFile(e) => write!(f, "Failed to create file: {}", e),
+        }
     }
 }

--- a/src/installer/step/common.rs
+++ b/src/installer/step/common.rs
@@ -1,6 +1,7 @@
 use crate::installer::{message, view};
 use iced::{button::State as Button, text_input, Element};
 
+#[derive(Clone)]
 pub struct ParticipantXpub {
     pub xpub: String,
     pub warning: bool,

--- a/src/installer/step/common.rs
+++ b/src/installer/step/common.rs
@@ -34,6 +34,31 @@ impl ParticipantXpub {
     }
 }
 
+#[derive(Clone)]
+pub struct RequiredXpub {
+    pub xpub: form::Value<String>,
+
+    xpub_input: text_input::State,
+}
+
+impl RequiredXpub {
+    pub fn new() -> Self {
+        Self {
+            xpub: form::Value::default(),
+            xpub_input: text_input::State::new(),
+        }
+    }
+
+    pub fn update(&mut self, msg: String) {
+        self.xpub.value = msg;
+        self.xpub.valid = true;
+    }
+
+    pub fn view(&mut self) -> Element<String> {
+        view::required_xpub(&self.xpub, &mut self.xpub_input)
+    }
+}
+
 pub struct CosignerKey {
     pub key: form::Value<String>,
 

--- a/src/installer/step/common.rs
+++ b/src/installer/step/common.rs
@@ -1,10 +1,13 @@
-use crate::installer::{message, view};
+use crate::{
+    installer::{message, view},
+    ui::component::form,
+};
+
 use iced::{button::State as Button, text_input, Element};
 
 #[derive(Clone)]
 pub struct ParticipantXpub {
-    pub xpub: String,
-    pub warning: bool,
+    pub xpub: form::Value<String>,
 
     xpub_input: text_input::State,
     delete_button: Button,
@@ -13,33 +16,26 @@ pub struct ParticipantXpub {
 impl ParticipantXpub {
     pub fn new() -> Self {
         Self {
-            xpub: "".to_string(),
+            xpub: form::Value::default(),
             xpub_input: text_input::State::new(),
             delete_button: Button::new(),
-            warning: false,
         }
     }
 
     pub fn update(&mut self, msg: message::ParticipantXpub) {
         if let message::ParticipantXpub::XpubEdited(xpub) = msg {
-            self.xpub = xpub;
-            self.warning = false;
+            self.xpub.value = xpub;
+            self.xpub.valid = true;
         }
     }
 
     pub fn view(&mut self) -> Element<message::ParticipantXpub> {
-        view::participant_xpub(
-            &self.xpub,
-            &mut self.xpub_input,
-            &mut self.delete_button,
-            self.warning,
-        )
+        view::participant_xpub(&self.xpub, &mut self.xpub_input, &mut self.delete_button)
     }
 }
 
 pub struct CosignerKey {
-    pub key: String,
-    pub warning: bool,
+    pub key: form::Value<String>,
 
     key_input: text_input::State,
     delete_button: Button,
@@ -48,26 +44,20 @@ pub struct CosignerKey {
 impl CosignerKey {
     pub fn new() -> Self {
         Self {
-            key: "".to_string(),
+            key: form::Value::default(),
             key_input: text_input::State::new(),
             delete_button: Button::new(),
-            warning: false,
         }
     }
 
     pub fn update(&mut self, msg: message::CosignerKey) {
         if let message::CosignerKey::KeyEdited(key) = msg {
-            self.key = key;
-            self.warning = false;
+            self.key.value = key;
+            self.key.valid = true;
         }
     }
 
     pub fn view(&mut self) -> Element<message::CosignerKey> {
-        view::cosigner_key(
-            &self.key,
-            &mut self.key_input,
-            &mut self.delete_button,
-            self.warning,
-        )
+        view::cosigner_key(&self.key, &mut self.key_input, &mut self.delete_button)
     }
 }

--- a/src/installer/step/common.rs
+++ b/src/installer/step/common.rs
@@ -1,0 +1,72 @@
+use crate::installer::{message, view};
+use iced::{button::State as Button, text_input, Element};
+
+pub struct ParticipantXpub {
+    pub xpub: String,
+    pub warning: bool,
+
+    xpub_input: text_input::State,
+    delete_button: Button,
+}
+
+impl ParticipantXpub {
+    pub fn new() -> Self {
+        Self {
+            xpub: "".to_string(),
+            xpub_input: text_input::State::new(),
+            delete_button: Button::new(),
+            warning: false,
+        }
+    }
+
+    pub fn update(&mut self, msg: message::ParticipantXpub) {
+        if let message::ParticipantXpub::XpubEdited(xpub) = msg {
+            self.xpub = xpub;
+            self.warning = false;
+        }
+    }
+
+    pub fn view(&mut self) -> Element<message::ParticipantXpub> {
+        view::participant_xpub(
+            &self.xpub,
+            &mut self.xpub_input,
+            &mut self.delete_button,
+            self.warning,
+        )
+    }
+}
+
+pub struct CosignerKey {
+    pub key: String,
+    pub warning: bool,
+
+    key_input: text_input::State,
+    delete_button: Button,
+}
+
+impl CosignerKey {
+    pub fn new() -> Self {
+        Self {
+            key: "".to_string(),
+            key_input: text_input::State::new(),
+            delete_button: Button::new(),
+            warning: false,
+        }
+    }
+
+    pub fn update(&mut self, msg: message::CosignerKey) {
+        if let message::CosignerKey::KeyEdited(key) = msg {
+            self.key = key;
+            self.warning = false;
+        }
+    }
+
+    pub fn view(&mut self) -> Element<message::CosignerKey> {
+        view::cosigner_key(
+            &self.key,
+            &mut self.key_input,
+            &mut self.delete_button,
+            self.warning,
+        )
+    }
+}

--- a/src/installer/step/common.rs
+++ b/src/installer/step/common.rs
@@ -38,7 +38,6 @@ pub struct CosignerKey {
     pub key: form::Value<String>,
 
     key_input: text_input::State,
-    delete_button: Button,
 }
 
 impl CosignerKey {
@@ -46,18 +45,15 @@ impl CosignerKey {
         Self {
             key: form::Value::default(),
             key_input: text_input::State::new(),
-            delete_button: Button::new(),
         }
     }
 
-    pub fn update(&mut self, msg: message::CosignerKey) {
-        if let message::CosignerKey::KeyEdited(key) = msg {
-            self.key.value = key;
-            self.key.valid = true;
-        }
+    pub fn update(&mut self, key: String) {
+        self.key.value = key;
+        self.key.valid = true;
     }
 
-    pub fn view(&mut self) -> Element<message::CosignerKey> {
-        view::cosigner_key(&self.key, &mut self.key_input, &mut self.delete_button)
+    pub fn view(&mut self) -> Element<String> {
+        view::cosigner_key(&self.key, &mut self.key_input)
     }
 }

--- a/src/installer/step/manager.rs
+++ b/src/installer/step/manager.rs
@@ -36,6 +36,12 @@ impl DefineStakeholderXpubs {
     }
 }
 
+impl Default for DefineStakeholderXpubs {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Step for DefineStakeholderXpubs {
     fn update_context(&self, ctx: &mut Context) {
         ctx.stakeholders_xpubs = self
@@ -154,6 +160,12 @@ impl DefineManagerXpubs {
             view: view::DefineManagerXpubsAsManager::new(),
             stakeholder_xpubs: Vec::new(),
         }
+    }
+}
+
+impl Default for DefineManagerXpubs {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -383,6 +395,12 @@ impl Cosigner {
     }
 }
 
+impl Default for Cosigner {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 pub struct DefineCosigners {
     cosigners: Vec<Cosigner>,
     view: view::DefineCosigners,
@@ -451,6 +469,12 @@ impl Step for DefineCosigners {
                 .map(|(i, xpub)| xpub.view().map(move |msg| Message::DefineCosigners(i, msg)))
                 .collect(),
         )
+    }
+}
+
+impl Default for DefineCosigners {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/installer/step/manager.rs
+++ b/src/installer/step/manager.rs
@@ -1,0 +1,216 @@
+use bitcoin::util::bip32::ExtendedPubKey;
+use iced::{button::State as Button, scrollable, text_input, Element};
+use std::str::FromStr;
+
+use crate::installer::{
+    message::{self, Message},
+    step::{
+        common::{CosignerKey, ParticipantXpub},
+        Step,
+    },
+    view,
+};
+
+pub struct DefineStakeholderXpubs {
+    stakeholder_xpubs: Vec<ParticipantXpub>,
+    add_xpub_button: Button,
+    scroll: scrollable::State,
+    previous_button: Button,
+    save_button: Button,
+}
+
+impl DefineStakeholderXpubs {
+    pub fn new() -> Self {
+        Self {
+            add_xpub_button: Button::new(),
+            stakeholder_xpubs: Vec::new(),
+            scroll: scrollable::State::new(),
+            previous_button: Button::new(),
+            save_button: Button::new(),
+        }
+    }
+}
+
+impl Step for DefineStakeholderXpubs {
+    fn is_correct(&self) -> bool {
+        !self.stakeholder_xpubs.iter().any(|xpub| xpub.warning)
+    }
+
+    fn check(&mut self) {
+        for participant in &mut self.stakeholder_xpubs {
+            if ExtendedPubKey::from_str(&participant.xpub).is_err() {
+                participant.warning = true;
+            }
+        }
+    }
+
+    fn update(&mut self, message: Message) {
+        if let Message::DefineStakeholderXpubs(msg) = message {
+            match msg {
+                message::DefineStakeholderXpubs::StakeholderXpub(
+                    i,
+                    message::ParticipantXpub::Delete,
+                ) => {
+                    self.stakeholder_xpubs.remove(i);
+                }
+                message::DefineStakeholderXpubs::StakeholderXpub(i, msg) => {
+                    if let Some(xpub) = self.stakeholder_xpubs.get_mut(i) {
+                        xpub.update(msg);
+                    }
+                }
+                message::DefineStakeholderXpubs::AddXpub => {
+                    self.stakeholder_xpubs.push(ParticipantXpub::new());
+                }
+                _ => (),
+            };
+        };
+    }
+
+    fn view(&mut self) -> Element<Message> {
+        return view::define_stakeholder_xpubs_as_manager_only(
+            &mut self.add_xpub_button,
+            self.stakeholder_xpubs
+                .iter_mut()
+                .enumerate()
+                .map(|(i, xpub)| {
+                    xpub.view().map(move |msg| {
+                        Message::DefineStakeholderXpubs(
+                            message::DefineStakeholderXpubs::StakeholderXpub(i, msg),
+                        )
+                    })
+                })
+                .collect(),
+            &mut self.scroll,
+            &mut self.previous_button,
+            &mut self.save_button,
+        );
+    }
+}
+
+impl From<DefineStakeholderXpubs> for Box<dyn Step> {
+    fn from(s: DefineStakeholderXpubs) -> Box<dyn Step> {
+        Box::new(s)
+    }
+}
+
+pub struct DefineManagerXpubs {
+    cosigners: Vec<CosignerKey>,
+    other_xpubs: Vec<ParticipantXpub>,
+    our_xpub: String,
+    our_xpub_warning: bool,
+
+    add_xpub_button: Button,
+    add_cosigner_button: Button,
+    our_xpub_input: text_input::State,
+    scroll: scrollable::State,
+    previous_button: Button,
+    save_button: Button,
+}
+
+impl DefineManagerXpubs {
+    pub fn new() -> Self {
+        Self {
+            our_xpub: "".to_string(),
+            our_xpub_input: text_input::State::new(),
+            our_xpub_warning: false,
+            other_xpubs: Vec::new(),
+            add_xpub_button: Button::new(),
+            scroll: scrollable::State::new(),
+            previous_button: Button::new(),
+            save_button: Button::new(),
+            cosigners: Vec::new(),
+            add_cosigner_button: Button::new(),
+        }
+    }
+}
+
+impl Step for DefineManagerXpubs {
+    fn check(&mut self) {
+        for participant in &mut self.other_xpubs {
+            if ExtendedPubKey::from_str(&participant.xpub).is_err() {
+                participant.warning = true;
+            }
+        }
+        if ExtendedPubKey::from_str(&self.our_xpub).is_err() {
+            self.our_xpub_warning = true;
+        }
+    }
+
+    fn is_correct(&self) -> bool {
+        !self.our_xpub_warning && !self.other_xpubs.iter().any(|xpub| xpub.warning)
+    }
+
+    fn update(&mut self, message: Message) {
+        if let Message::DefineManagerXpubs(msg) = message {
+            match msg {
+                message::DefineManagerXpubs::OurXpubEdited(xpub) => {
+                    self.our_xpub = xpub;
+                    self.our_xpub_warning = false;
+                }
+                message::DefineManagerXpubs::ManagerXpub(i, message::ParticipantXpub::Delete) => {
+                    self.other_xpubs.remove(i);
+                }
+                message::DefineManagerXpubs::ManagerXpub(i, msg) => {
+                    if let Some(xpub) = self.other_xpubs.get_mut(i) {
+                        xpub.update(msg)
+                    };
+                }
+                message::DefineManagerXpubs::AddXpub => {
+                    self.other_xpubs.push(ParticipantXpub::new());
+                }
+                message::DefineManagerXpubs::CosignerKey(i, message::CosignerKey::Delete) => {
+                    self.cosigners.remove(i);
+                }
+                message::DefineManagerXpubs::CosignerKey(i, msg) => {
+                    if let Some(key) = self.cosigners.get_mut(i) {
+                        key.update(msg)
+                    };
+                }
+                message::DefineManagerXpubs::AddCosigner => {
+                    self.cosigners.push(CosignerKey::new());
+                }
+            };
+        };
+    }
+
+    fn view(&mut self) -> Element<Message> {
+        return view::define_manager_xpubs_as_manager(
+            &self.our_xpub,
+            &mut self.our_xpub_input,
+            self.our_xpub_warning,
+            &mut self.add_xpub_button,
+            self.other_xpubs
+                .iter_mut()
+                .enumerate()
+                .map(|(i, xpub)| {
+                    xpub.view().map(move |msg| {
+                        Message::DefineManagerXpubs(message::DefineManagerXpubs::ManagerXpub(
+                            i, msg,
+                        ))
+                    })
+                })
+                .collect(),
+            &mut self.add_cosigner_button,
+            self.cosigners
+                .iter_mut()
+                .enumerate()
+                .map(|(i, xpub)| {
+                    xpub.view().map(move |msg| {
+                        Message::DefineManagerXpubs(message::DefineManagerXpubs::CosignerKey(
+                            i, msg,
+                        ))
+                    })
+                })
+                .collect(),
+            &mut self.scroll,
+            &mut self.previous_button,
+            &mut self.save_button,
+        );
+    }
+}
+
+impl From<DefineManagerXpubs> for Box<dyn Step> {
+    fn from(s: DefineManagerXpubs) -> Box<dyn Step> {
+        Box::new(s)
+    }
+}

--- a/src/installer/step/manager.rs
+++ b/src/installer/step/manager.rs
@@ -289,7 +289,7 @@ impl Step for DefineManagerXpubs {
 
         managers_xpubs.sort();
 
-        let managers_keys = managers_xpubs
+        let managers_keys: Vec<DescriptorPublicKey> = managers_xpubs
             .into_iter()
             .map(|xpub| DescriptorPublicKey::from_str(&xpub).expect("already checked"))
             .collect();
@@ -321,6 +321,7 @@ impl Step for DefineManagerXpubs {
             .collect();
 
         ctx.number_cosigners = self.cosigners.len();
+        ctx.number_managers = managers_keys.len();
 
         config.manager_config = Some(config::ManagerConfig {
             xpub: ExtendedPubKey::from_str(&self.our_xpub.value).expect("already checked"),

--- a/src/installer/step/manager.rs
+++ b/src/installer/step/manager.rs
@@ -164,9 +164,9 @@ pub struct DefineManagerXpubs {
 impl DefineManagerXpubs {
     pub fn new() -> Self {
         Self {
-            managers_threshold: 0,
+            managers_threshold: 1,
             threshold_warning: false,
-            spending_delay: 0,
+            spending_delay: 10,
             spending_delay_warning: false,
             our_xpub: form::Value::default(),
             other_xpubs: Vec::new(),

--- a/src/installer/step/manager.rs
+++ b/src/installer/step/manager.rs
@@ -98,28 +98,22 @@ pub struct DefineManagerXpubs {
     other_xpubs: Vec<ParticipantXpub>,
     our_xpub: String,
     our_xpub_warning: bool,
+    managers_treshold: u32,
+    spending_delay: u32,
 
-    add_xpub_button: Button,
-    add_cosigner_button: Button,
-    our_xpub_input: text_input::State,
-    scroll: scrollable::State,
-    previous_button: Button,
-    save_button: Button,
+    view: view::DefineManagerXpubsAsManager,
 }
 
 impl DefineManagerXpubs {
     pub fn new() -> Self {
         Self {
+            managers_treshold: 0,
+            spending_delay: 0,
             our_xpub: "".to_string(),
-            our_xpub_input: text_input::State::new(),
             our_xpub_warning: false,
             other_xpubs: Vec::new(),
-            add_xpub_button: Button::new(),
-            scroll: scrollable::State::new(),
-            previous_button: Button::new(),
-            save_button: Button::new(),
             cosigners: Vec::new(),
-            add_cosigner_button: Button::new(),
+            view: view::DefineManagerXpubsAsManager::new(),
         }
     }
 }
@@ -169,16 +163,36 @@ impl Step for DefineManagerXpubs {
                 message::DefineManagerXpubs::AddCosigner => {
                     self.cosigners.push(CosignerKey::new());
                 }
+                message::DefineManagerXpubs::ManagersTreshold(action) => match action {
+                    message::Action::Increment => {
+                        self.managers_treshold = self.managers_treshold + 1;
+                    }
+                    message::Action::Decrement => {
+                        if self.managers_treshold > 0 {
+                            self.managers_treshold = self.managers_treshold - 1;
+                        }
+                    }
+                },
+                message::DefineManagerXpubs::SpendingDelay(action) => match action {
+                    message::Action::Increment => {
+                        self.spending_delay = self.spending_delay + 1;
+                    }
+                    message::Action::Decrement => {
+                        if self.spending_delay > 0 {
+                            self.spending_delay = self.spending_delay - 1;
+                        }
+                    }
+                },
             };
         };
     }
 
     fn view(&mut self) -> Element<Message> {
-        return view::define_manager_xpubs_as_manager(
+        return self.view.render(
+            self.managers_treshold,
+            self.spending_delay,
             &self.our_xpub,
-            &mut self.our_xpub_input,
             self.our_xpub_warning,
-            &mut self.add_xpub_button,
             self.other_xpubs
                 .iter_mut()
                 .enumerate()
@@ -190,7 +204,6 @@ impl Step for DefineManagerXpubs {
                     })
                 })
                 .collect(),
-            &mut self.add_cosigner_button,
             self.cosigners
                 .iter_mut()
                 .enumerate()
@@ -202,9 +215,6 @@ impl Step for DefineManagerXpubs {
                     })
                 })
                 .collect(),
-            &mut self.scroll,
-            &mut self.previous_button,
-            &mut self.save_button,
         );
     }
 }

--- a/src/installer/step/manager.rs
+++ b/src/installer/step/manager.rs
@@ -149,8 +149,8 @@ pub struct DefineManagerXpubs {
     cosigners: Vec<CosignerKey>,
     other_xpubs: Vec<ParticipantXpub>,
     our_xpub: form::Value<String>,
-    managers_treshold: usize,
-    treshold_warning: bool,
+    managers_threshold: usize,
+    threshold_warning: bool,
     spending_delay: u32,
     spending_delay_warning: bool,
     warning: Option<String>,
@@ -164,8 +164,8 @@ pub struct DefineManagerXpubs {
 impl DefineManagerXpubs {
     pub fn new() -> Self {
         Self {
-            managers_treshold: 0,
-            treshold_warning: false,
+            managers_threshold: 0,
+            threshold_warning: false,
             spending_delay: 0,
             spending_delay_warning: false,
             our_xpub: form::Value::default(),
@@ -218,15 +218,15 @@ impl Step for DefineManagerXpubs {
                 message::DefineManagerXpubs::AddCosigner => {
                     self.cosigners.push(CosignerKey::new());
                 }
-                message::DefineManagerXpubs::ManagersTreshold(action) => match action {
+                message::DefineManagerXpubs::ManagersThreshold(action) => match action {
                     message::Action::Increment => {
-                        self.treshold_warning = false;
-                        self.managers_treshold += 1;
+                        self.threshold_warning = false;
+                        self.managers_threshold += 1;
                     }
                     message::Action::Decrement => {
-                        self.treshold_warning = false;
-                        if self.managers_treshold > 0 {
-                            self.managers_treshold -= 1;
+                        self.threshold_warning = false;
+                        if self.managers_threshold > 0 {
+                            self.managers_threshold -= 1;
                         }
                     }
                 },
@@ -257,9 +257,9 @@ impl Step for DefineManagerXpubs {
             cosigner.key.valid = DescriptorPublicKey::from_str(&cosigner.key.value).is_ok();
         }
 
-        // If user is manager, other_xpubs can be equal to zero and treshold equal to 1.
-        self.treshold_warning =
-            self.managers_treshold == 0 || self.managers_treshold > self.other_xpubs.len() + 1;
+        // If user is manager, other_xpubs can be equal to zero and threshold equal to 1.
+        self.threshold_warning =
+            self.managers_threshold == 0 || self.managers_threshold > self.other_xpubs.len() + 1;
         self.spending_delay_warning = self.spending_delay == 0;
 
         if !self.our_xpub.valid
@@ -268,7 +268,7 @@ impl Step for DefineManagerXpubs {
                 .iter()
                 .any(|participant| !participant.xpub.valid)
             || self.cosigners.iter().any(|cosigner| !cosigner.key.valid)
-            || self.treshold_warning
+            || self.threshold_warning
             || self.spending_delay_warning
         {
             return false;
@@ -324,7 +324,7 @@ impl Step for DefineManagerXpubs {
         match UnvaultDescriptor::new(
             stakeholders_keys,
             managers_keys,
-            self.managers_treshold,
+            self.managers_threshold,
             cosigners_keys,
             self.spending_delay,
         ) {
@@ -340,8 +340,8 @@ impl Step for DefineManagerXpubs {
 
     fn view(&mut self) -> Element<Message> {
         return self.view.render(
-            self.managers_treshold,
-            self.treshold_warning,
+            self.managers_threshold,
+            self.threshold_warning,
             self.spending_delay,
             self.spending_delay_warning,
             &self.our_xpub,

--- a/src/installer/step/manager.rs
+++ b/src/installer/step/manager.rs
@@ -1,8 +1,10 @@
+use std::cmp::Ordering;
+use std::str::FromStr;
+
 use bitcoin::util::bip32::ExtendedPubKey;
 use iced::{button::State as Button, scrollable, Element};
 use miniscript::DescriptorPublicKey;
 use revault_tx::scripts::{DepositDescriptor, UnvaultDescriptor};
-use std::str::FromStr;
 
 use crate::{
     installer::{
@@ -418,10 +420,12 @@ impl DefineCosigners {
 impl Step for DefineCosigners {
     fn load_context(&mut self, ctx: &Context) {
         while self.cosigners.len() != ctx.number_cosigners {
-            if self.cosigners.len() > ctx.number_cosigners {
-                self.cosigners.pop();
-            } else if self.cosigners.len() < ctx.number_cosigners {
-                self.cosigners.push(Cosigner::new());
+            match self.cosigners.len().cmp(&ctx.number_cosigners) {
+                Ordering::Greater => {
+                    self.cosigners.pop();
+                }
+                Ordering::Less => self.cosigners.push(Cosigner::new()),
+                Ordering::Equal => (),
             }
         }
     }

--- a/src/installer/step/manager.rs
+++ b/src/installer/step/manager.rs
@@ -230,24 +230,24 @@ impl Step for DefineManagerXpubs {
                 message::DefineManagerXpubs::ManagersTreshold(action) => match action {
                     message::Action::Increment => {
                         self.treshold_warning = false;
-                        self.managers_treshold = self.managers_treshold + 1;
+                        self.managers_treshold += 1;
                     }
                     message::Action::Decrement => {
                         self.treshold_warning = false;
                         if self.managers_treshold > 0 {
-                            self.managers_treshold = self.managers_treshold - 1;
+                            self.managers_treshold -= 1;
                         }
                     }
                 },
                 message::DefineManagerXpubs::SpendingDelay(action) => match action {
                     message::Action::Increment => {
                         self.spending_delay_warning = false;
-                        self.spending_delay = self.spending_delay + 1;
+                        self.spending_delay += 1;
                     }
                     message::Action::Decrement => {
                         self.spending_delay_warning = false;
                         if self.spending_delay > 0 {
-                            self.spending_delay = self.spending_delay - 1;
+                            self.spending_delay -= 1;
                         }
                     }
                 },

--- a/src/installer/step/mod.rs
+++ b/src/installer/step/mod.rs
@@ -1,0 +1,77 @@
+mod common;
+pub mod manager;
+pub mod stakeholder;
+
+use iced::{button::State as Button, scrollable, Element};
+
+use crate::installer::{message::Message, view};
+
+pub trait Step {
+    fn check(&mut self) {}
+    fn update(&mut self, message: Message);
+    fn view(&mut self) -> Element<Message>;
+    fn is_correct(&self) -> bool {
+        true
+    }
+}
+
+pub struct Welcome {
+    install_button: Button,
+}
+
+impl Welcome {
+    pub fn new() -> Self {
+        Self {
+            install_button: Button::new(),
+        }
+    }
+}
+
+impl Step for Welcome {
+    fn update(&mut self, _message: Message) {}
+    fn view(&mut self) -> Element<Message> {
+        view::welcome(&mut self.install_button)
+    }
+}
+
+impl From<Welcome> for Box<dyn Step> {
+    fn from(s: Welcome) -> Box<dyn Step> {
+        Box::new(s)
+    }
+}
+
+pub struct DefineRole {
+    stakeholder_button: Button,
+    manager_button: Button,
+    stakeholder_manager_button: Button,
+    scroll: scrollable::State,
+}
+
+impl DefineRole {
+    pub fn new() -> Self {
+        Self {
+            stakeholder_button: Button::new(),
+            manager_button: Button::new(),
+            stakeholder_manager_button: Button::new(),
+            scroll: scrollable::State::new(),
+        }
+    }
+}
+
+impl Step for DefineRole {
+    fn update(&mut self, _message: Message) {}
+    fn view(&mut self) -> Element<Message> {
+        view::define_role(
+            &mut self.stakeholder_button,
+            &mut self.manager_button,
+            &mut self.stakeholder_manager_button,
+            &mut self.scroll,
+        )
+    }
+}
+
+impl From<DefineRole> for Box<dyn Step> {
+    fn from(s: DefineRole) -> Box<dyn Step> {
+        Box::new(s)
+    }
+}

--- a/src/installer/step/mod.rs
+++ b/src/installer/step/mod.rs
@@ -381,7 +381,7 @@ impl DefineBitcoind {
         Self {
             network: bitcoin::Network::Bitcoin,
             cookie_path: form::Value {
-                value: bitcoin_cookie_path().unwrap_or("".to_string()),
+                value: bitcoin_cookie_path().unwrap_or_else(String::new),
                 valid: true,
             },
             address: form::Value {

--- a/src/installer/step/mod.rs
+++ b/src/installer/step/mod.rs
@@ -5,7 +5,7 @@ pub mod stakeholder;
 use std::path::PathBuf;
 use std::str::FromStr;
 
-use bitcoin::{util::bip32::ExtendedPubKey, Network};
+use bitcoin::util::bip32::ExtendedPubKey;
 use iced::{button::State as Button, scrollable, Element};
 use miniscript::DescriptorPublicKey;
 use revault_tx::scripts::CpfpDescriptor;
@@ -285,6 +285,7 @@ impl From<DefineCoordinator> for Box<dyn Step> {
 }
 
 pub struct DefineBitcoind {
+    network: bitcoin::Network,
     cookie_path: String,
     address: String,
 
@@ -297,6 +298,7 @@ pub struct DefineBitcoind {
 impl DefineBitcoind {
     pub fn new() -> Self {
         Self {
+            network: bitcoin::Network::Bitcoin,
             cookie_path: "".to_string(),
             address: "".to_string(),
             warning_cookie: false,
@@ -328,13 +330,16 @@ impl Step for DefineBitcoind {
                     self.cookie_path = path;
                     self.warning_cookie = false;
                 }
+                message::DefineBitcoind::NetworkEdited(network) => {
+                    self.network = network;
+                }
             };
         };
     }
 
     fn edit_config(&self, config: &mut config::Config) {
         config.bitcoind_config = config::BitcoindConfig {
-            network: Network::from_str("bitcoin").expect("already checked"),
+            network: self.network,
             cookie_path: PathBuf::from_str(&self.cookie_path).expect("already checked"),
             poll_interval_secs: None,
             addr: std::net::SocketAddr::from_str(&self.address).expect("already checked"),
@@ -343,6 +348,7 @@ impl Step for DefineBitcoind {
 
     fn view(&mut self) -> Element<Message> {
         self.view.render(
+            &self.network,
             &self.address,
             &self.cookie_path,
             self.warning_address,

--- a/src/installer/step/mod.rs
+++ b/src/installer/step/mod.rs
@@ -159,3 +159,51 @@ impl From<DefineCpfpDescriptor> for Box<dyn Step> {
         Box::new(s)
     }
 }
+
+pub struct DefineCoordinator {
+    host: String,
+    noise_key: String,
+    warning: bool,
+
+    view: view::DefineCoordinator,
+}
+
+impl DefineCoordinator {
+    pub fn new() -> Self {
+        Self {
+            host: "".to_string(),
+            noise_key: "".to_string(),
+            warning: false,
+            view: view::DefineCoordinator::new(),
+        }
+    }
+}
+
+impl Step for DefineCoordinator {
+    fn is_correct(&self) -> bool {
+        !self.warning
+    }
+
+    fn check(&mut self) {
+        // TODO
+    }
+
+    fn update(&mut self, message: Message) {
+        if let Message::DefineCoordinator(msg) = message {
+            match msg {
+                message::DefineCoordinator::HostEdited(host) => self.host = host,
+                message::DefineCoordinator::NoiseKeyEdited(key) => self.noise_key = key,
+            };
+        };
+    }
+
+    fn view(&mut self) -> Element<Message> {
+        self.view.render(&self.host, &self.noise_key, self.warning)
+    }
+}
+
+impl From<DefineCoordinator> for Box<dyn Step> {
+    fn from(s: DefineCoordinator) -> Box<dyn Step> {
+        Box::new(s)
+    }
+}

--- a/src/installer/step/mod.rs
+++ b/src/installer/step/mod.rs
@@ -464,7 +464,7 @@ mod tests {
             step.update(Message::DefineStakeholderXpubs(
                 DefineStakeholderXpubs::StakeholderXpub(i, ParticipantXpub::XpubEdited(xpub)),
             ));
-            i = i + 1;
+            i += 1;
         }
     }
 
@@ -475,7 +475,7 @@ mod tests {
             step.update(Message::DefineManagerXpubs(
                 DefineManagerXpubs::ManagerXpub(i, ParticipantXpub::XpubEdited(xpub)),
             ));
-            i = i + 1;
+            i += 1;
         }
     }
 
@@ -486,7 +486,7 @@ mod tests {
             step.update(Message::DefineManagerXpubs(
                 DefineManagerXpubs::CosignerKey(i, CosignerKey::KeyEdited(key)),
             ));
-            i = i + 1;
+            i += 1;
         }
     }
 
@@ -645,5 +645,10 @@ mod tests {
 
         let mut cpfp_2_config = Config::new();
         cpfp_2_step.edit_config(&mut cpfp_2_config);
+
+        assert_eq!(
+            cpfp_1_config.scripts_config.cpfp_descriptor,
+            cpfp_2_config.scripts_config.cpfp_descriptor,
+        );
     }
 }

--- a/src/installer/step/mod.rs
+++ b/src/installer/step/mod.rs
@@ -148,7 +148,7 @@ impl Step for DefinePrivateNoiseKey {
     fn update(&mut self, message: Message) {
         if let Message::PrivateNoiseKey(msg) = message {
             self.key.value = msg;
-            self.key.valid = true;
+            self.key.valid = self.key.value.as_bytes().len() == 32;
         }
     }
     fn apply(&mut self, ctx: &mut Context, _config: &mut config::Config) -> bool {

--- a/src/installer/step/mod.rs
+++ b/src/installer/step/mod.rs
@@ -484,9 +484,8 @@ mod tests {
     fn load_cosigners_keys(step: &mut dyn Step, keys: Vec<String>) {
         let mut i = 0;
         for key in keys {
-            step.update(Message::DefineManagerXpubs(DefineManagerXpubs::AddCosigner));
             step.update(Message::DefineManagerXpubs(
-                DefineManagerXpubs::CosignerKey(i, CosignerKey::KeyEdited(key)),
+                DefineManagerXpubs::CosignerKey(i, key),
             ));
             i += 1;
         }
@@ -536,6 +535,7 @@ mod tests {
         let mut ctx = Context::new();
         let mut manager_step = manager::DefineManagerXpubs::new();
         manager_step.load_context(&Context {
+            number_managers: 1,
             number_cosigners: 4,
             stakeholders_xpubs: vec![
                 STAKEHOLDERS_XPUBS[2].to_string(),
@@ -572,6 +572,7 @@ mod tests {
 
         let mut stakeholder_step = stakeholder::DefineManagerXpubs::new();
         stakeholder_step.load_context(&Context {
+            number_managers: 1,
             number_cosigners: 4,
             stakeholders_xpubs: vec![
                 STAKEHOLDERS_XPUBS[3].to_string(),

--- a/src/installer/step/mod.rs
+++ b/src/installer/step/mod.rs
@@ -313,12 +313,37 @@ pub struct DefineBitcoind {
     view: view::DefineBitcoind,
 }
 
+fn bitcoin_cookie_path() -> Option<String> {
+    #[cfg(target_os = "linux")]
+    let configs_dir = dirs::home_dir();
+
+    #[cfg(not(target_os = "linux"))]
+    let configs_dir = dirs::config_dir();
+
+    if let Some(mut path) = configs_dir {
+        #[cfg(target_os = "linux")]
+        path.push(".bitcoin/.cookie");
+
+        #[cfg(not(target_os = "linux"))]
+        path.push("Bitcoin/.cookie");
+
+        return path.to_str().map(|s| s.to_string());
+    }
+    None
+}
+
 impl DefineBitcoind {
     pub fn new() -> Self {
         Self {
             network: bitcoin::Network::Bitcoin,
-            cookie_path: form::Value::default(),
-            address: form::Value::default(),
+            cookie_path: form::Value {
+                value: bitcoin_cookie_path().unwrap_or("".to_string()),
+                valid: true,
+            },
+            address: form::Value {
+                value: "127.0.0.1:8332".to_string(),
+                valid: true,
+            },
             view: view::DefineBitcoind::new(),
         }
     }

--- a/src/installer/step/mod.rs
+++ b/src/installer/step/mod.rs
@@ -4,6 +4,7 @@ pub mod stakeholder;
 
 use bitcoin::util::bip32::ExtendedPubKey;
 use iced::{button::State as Button, scrollable, Element};
+use std::path::PathBuf;
 use std::str::FromStr;
 
 use crate::installer::{
@@ -218,6 +219,69 @@ impl Step for DefineCoordinator {
 
 impl From<DefineCoordinator> for Box<dyn Step> {
     fn from(s: DefineCoordinator) -> Box<dyn Step> {
+        Box::new(s)
+    }
+}
+
+pub struct DefineBitcoind {
+    cookie_path: String,
+    address: String,
+
+    warning_cookie: bool,
+    warning_address: bool,
+
+    view: view::DefineBitcoind,
+}
+
+impl DefineBitcoind {
+    pub fn new() -> Self {
+        Self {
+            cookie_path: "".to_string(),
+            address: "".to_string(),
+            warning_cookie: false,
+            warning_address: false,
+            view: view::DefineBitcoind::new(),
+        }
+    }
+}
+
+impl Step for DefineBitcoind {
+    fn is_correct(&self) -> bool {
+        !self.warning_address && !self.warning_cookie
+    }
+
+    fn check(&mut self) {
+        self.warning_cookie = PathBuf::from_str(&self.cookie_path).is_err();
+        // TODO
+    }
+
+    fn update(&mut self, message: Message) {
+        if let Message::DefineBitcoind(msg) = message {
+            match msg {
+                message::DefineBitcoind::AddressEdited(address) => {
+                    self.address = address;
+                    self.warning_address = false;
+                }
+                message::DefineBitcoind::CookiePathEdited(path) => {
+                    self.cookie_path = path;
+                    self.warning_cookie = false;
+                }
+            };
+        };
+    }
+
+    fn view(&mut self) -> Element<Message> {
+        self.view.render(
+            &self.address,
+            &self.cookie_path,
+            self.warning_address,
+            self.warning_cookie,
+        )
+    }
+}
+
+impl From<DefineBitcoind> for Box<dyn Step> {
+    fn from(s: DefineBitcoind) -> Box<dyn Step> {
         Box::new(s)
     }
 }

--- a/src/installer/step/mod.rs
+++ b/src/installer/step/mod.rs
@@ -16,8 +16,22 @@ pub trait Step {
     fn check(&mut self) {}
     fn update(&mut self, message: Message);
     fn view(&mut self) -> Element<Message>;
+    fn update_context(&self, _ctx: &mut Context) {}
+    fn load_context(&mut self, _ctx: &Context) {}
     fn is_correct(&self) -> bool {
         true
+    }
+}
+
+pub struct Context {
+    pub number_cosigners: usize,
+}
+
+impl Context {
+    pub fn new() -> Self {
+        Self {
+            number_cosigners: 0,
+        }
     }
 }
 

--- a/src/installer/step/mod.rs
+++ b/src/installer/step/mod.rs
@@ -2,9 +2,15 @@ mod common;
 pub mod manager;
 pub mod stakeholder;
 
+use bitcoin::util::bip32::ExtendedPubKey;
 use iced::{button::State as Button, scrollable, Element};
+use std::str::FromStr;
 
-use crate::installer::{message::Message, view};
+use crate::installer::{
+    message::{self, Message},
+    step::common::ParticipantXpub,
+    view,
+};
 
 pub trait Step {
     fn check(&mut self) {}
@@ -72,6 +78,84 @@ impl Step for DefineRole {
 
 impl From<DefineRole> for Box<dyn Step> {
     fn from(s: DefineRole) -> Box<dyn Step> {
+        Box::new(s)
+    }
+}
+
+pub struct DefineCpfpDescriptor {
+    manager_xpubs: Vec<ParticipantXpub>,
+    add_xpub_button: Button,
+    scroll: scrollable::State,
+    previous_button: Button,
+    save_button: Button,
+}
+
+impl DefineCpfpDescriptor {
+    pub fn new() -> Self {
+        Self {
+            add_xpub_button: Button::new(),
+            manager_xpubs: Vec::new(),
+            scroll: scrollable::State::new(),
+            previous_button: Button::new(),
+            save_button: Button::new(),
+        }
+    }
+}
+
+impl Step for DefineCpfpDescriptor {
+    fn is_correct(&self) -> bool {
+        !self.manager_xpubs.iter().any(|xpub| xpub.warning)
+    }
+
+    fn check(&mut self) {
+        for participant in &mut self.manager_xpubs {
+            if ExtendedPubKey::from_str(&participant.xpub).is_err() {
+                participant.warning = true;
+            }
+        }
+    }
+
+    fn update(&mut self, message: Message) {
+        if let Message::DefineCpfpDescriptor(msg) = message {
+            match msg {
+                message::DefineCpfpDescriptor::ManagerXpub(i, message::ParticipantXpub::Delete) => {
+                    self.manager_xpubs.remove(i);
+                }
+                message::DefineCpfpDescriptor::ManagerXpub(i, msg) => {
+                    if let Some(xpub) = self.manager_xpubs.get_mut(i) {
+                        xpub.update(msg);
+                    }
+                }
+                message::DefineCpfpDescriptor::AddXpub => {
+                    self.manager_xpubs.push(ParticipantXpub::new());
+                }
+            };
+        };
+    }
+
+    fn view(&mut self) -> Element<Message> {
+        return view::define_cpfp_descriptor(
+            &mut self.add_xpub_button,
+            self.manager_xpubs
+                .iter_mut()
+                .enumerate()
+                .map(|(i, xpub)| {
+                    xpub.view().map(move |msg| {
+                        Message::DefineCpfpDescriptor(message::DefineCpfpDescriptor::ManagerXpub(
+                            i, msg,
+                        ))
+                    })
+                })
+                .collect(),
+            &mut self.scroll,
+            &mut self.previous_button,
+            &mut self.save_button,
+        );
+    }
+}
+
+impl From<DefineCpfpDescriptor> for Box<dyn Step> {
+    fn from(s: DefineCpfpDescriptor) -> Box<dyn Step> {
         Box::new(s)
     }
 }

--- a/src/installer/step/mod.rs
+++ b/src/installer/step/mod.rs
@@ -164,19 +164,21 @@ impl Step for DefineCpfpDescriptor {
 
     fn apply(&mut self, _ctx: &mut Context, config: &mut config::Config) -> bool {
         for participant in &mut self.manager_xpubs {
-            if ExtendedPubKey::from_str(&participant.xpub).is_err() {
-                participant.warning = true;
-            }
+            participant.xpub.valid = ExtendedPubKey::from_str(&participant.xpub.value).is_ok()
         }
 
-        if self.manager_xpubs.iter().any(|xpub| xpub.warning) {
+        if self
+            .manager_xpubs
+            .iter()
+            .any(|participant| !participant.xpub.valid)
+        {
             return false;
         }
 
         let mut xpubs: Vec<String> = self
             .manager_xpubs
             .iter()
-            .map(|participant| format!("{}/*", participant.xpub))
+            .map(|participant| format!("{}/*", participant.xpub.value))
             .collect();
 
         xpubs.sort();

--- a/src/installer/step/mod.rs
+++ b/src/installer/step/mod.rs
@@ -377,3 +377,221 @@ impl From<Final> for Box<dyn Step> {
         Box::new(s)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{DefineCpfpDescriptor as DefineCpfpDescriptorStep, *};
+    use crate::installer::message::{DefineCpfpDescriptor, ParticipantXpub, *};
+    use crate::revaultd::config::Config;
+
+    const STAKEHOLDERS_XPUBS: [&str; 4] = [
+        "xpub6DEzq5DNPx2rPiZJ7wvFhxRKUKDoV1GwjFmFdaxFfbsw9HsHyxc9usoRUMxqJaMrwoXh4apahsGEnjAS4cVCBDgqsx5Groww22AdHbgxVDg", 
+        "xpub6F7Ltmsut73cbUNAzh44DkxncMeQfPtRzx7aoXjFbUdd7yofR2intU4b6QcsXot1jgmVjHB3iMybCLhtqvhAx3L4VPbGUz5fwuyNeTkypUP",
+        "xpub6CutNDrGhiD8GbjgKQWoTfzdRmoHJT8AcBxaV4NvWmo4dE5KKwpg2ukvgiCRwgZuJRXxKRsgRrrZiDZFJw1rLyAvY7X52WNEuaJXcVKLVFG", 
+        "xpub6EN35Df8V826n4HuW4QZEhFyyMq4jmou3AFnVqRpoFw8YS68ojkVNzVGWhnkCyGwZjVVUEoeBWhTfJ38C3Fvsc3ibvYFi5BvmQwAMZkqEqH"
+    ];
+
+    const MANAGERS_XPUBS: [&str; 2] = [
+        "xpub6CZFHPW1GiB8YgV7zGpeQDB6mMHZYPQyUaHrM1nMvKMgLxwok4xCtnzjuxQ3p1LHJUkz5i1Y7bRy5fmGrdg8UBVb39XdXNtWWd2wTsNd7T9",
+        "xpub6Doj75MBvKp7bgHxF1KeDGxm36rd4wonZWv8sfzTeNoNVX2QZaQdrEcs7NDXvs4Cbsy9TPMx5VDcMK6JjSKepBbYDPiJ9bLBR4bqfdHmxZx",
+    ];
+
+    const COSIGNERS_KEYS: [&str; 4] = [
+        "030f64b922aee2fd597f104bc6cb3b670f1ca2c6c49b1071a1a6c010575d94fe5a",
+        "02abe475b199ec3d62fa576faee16a334fdb86ffb26dce75becebaaedf328ac3fe",
+        "0314f3dc33595b0d016bb522f6fe3a67680723d842c1b9b8ae6b59fdd8ab5cccb4",
+        "025eba3305bd3c829e4e1551aac7358e4178832c739e4fc4729effe428de0398ab",
+    ];
+
+    fn load_stakeholders_xpubs(step: &mut dyn Step, xpubs: Vec<String>) {
+        let mut i = 0;
+        for xpub in xpubs {
+            step.update(Message::DefineStakeholderXpubs(
+                DefineStakeholderXpubs::AddXpub,
+            ));
+            step.update(Message::DefineStakeholderXpubs(
+                DefineStakeholderXpubs::StakeholderXpub(i, ParticipantXpub::XpubEdited(xpub)),
+            ));
+            i = i + 1;
+        }
+    }
+
+    fn load_managers_xpubs(step: &mut dyn Step, xpubs: Vec<String>) {
+        let mut i = 0;
+        for xpub in xpubs {
+            step.update(Message::DefineManagerXpubs(DefineManagerXpubs::AddXpub));
+            step.update(Message::DefineManagerXpubs(
+                DefineManagerXpubs::ManagerXpub(i, ParticipantXpub::XpubEdited(xpub)),
+            ));
+            i = i + 1;
+        }
+    }
+
+    fn load_cosigners_keys(step: &mut dyn Step, keys: Vec<String>) {
+        let mut i = 0;
+        for key in keys {
+            step.update(Message::DefineManagerXpubs(DefineManagerXpubs::AddCosigner));
+            step.update(Message::DefineManagerXpubs(
+                DefineManagerXpubs::CosignerKey(i, CosignerKey::KeyEdited(key)),
+            ));
+            i = i + 1;
+        }
+    }
+
+    #[test]
+    fn define_deposit_descriptor() {
+        let mut manager_step = manager::DefineStakeholderXpubs::new();
+        load_stakeholders_xpubs(
+            &mut manager_step,
+            vec![
+                STAKEHOLDERS_XPUBS[2].to_string(),
+                STAKEHOLDERS_XPUBS[1].to_string(),
+                STAKEHOLDERS_XPUBS[0].to_string(),
+                STAKEHOLDERS_XPUBS[3].to_string(),
+            ],
+        );
+
+        let mut manager_config = Config::new();
+        manager_step.edit_config(&mut manager_config);
+
+        let mut stakeholder_step = stakeholder::DefineStakeholderXpubs::new();
+        load_stakeholders_xpubs(
+            &mut stakeholder_step,
+            vec![
+                STAKEHOLDERS_XPUBS[3].to_string(),
+                STAKEHOLDERS_XPUBS[0].to_string(),
+                STAKEHOLDERS_XPUBS[1].to_string(),
+            ],
+        );
+        stakeholder_step.update(Message::DefineStakeholderXpubs(
+            DefineStakeholderXpubs::OurXpubEdited(STAKEHOLDERS_XPUBS[2].to_string()),
+        ));
+
+        let mut stakeholder_config = Config::new();
+        stakeholder_step.edit_config(&mut stakeholder_config);
+
+        assert_eq!(
+            manager_config.scripts_config.deposit_descriptor,
+            stakeholder_config.scripts_config.deposit_descriptor,
+        );
+    }
+
+    #[test]
+    fn define_unvault_descriptor() {
+        let mut manager_step = manager::DefineManagerXpubs::new();
+        manager_step.load_context(&Context {
+            number_cosigners: 4,
+            stakeholders_xpubs: vec![
+                STAKEHOLDERS_XPUBS[2].to_string(),
+                STAKEHOLDERS_XPUBS[1].to_string(),
+                STAKEHOLDERS_XPUBS[0].to_string(),
+                STAKEHOLDERS_XPUBS[3].to_string(),
+            ],
+        });
+
+        load_managers_xpubs(&mut manager_step, vec![MANAGERS_XPUBS[0].to_string()]);
+        load_cosigners_keys(
+            &mut manager_step,
+            vec![
+                COSIGNERS_KEYS[2].to_string(),
+                COSIGNERS_KEYS[1].to_string(),
+                COSIGNERS_KEYS[0].to_string(),
+                COSIGNERS_KEYS[3].to_string(),
+            ],
+        );
+
+        manager_step.update(Message::DefineManagerXpubs(
+            DefineManagerXpubs::OurXpubEdited(MANAGERS_XPUBS[1].to_string()),
+        ));
+
+        manager_step.update(Message::DefineManagerXpubs(
+            DefineManagerXpubs::ManagersTreshold(Action::Increment),
+        ));
+        manager_step.update(Message::DefineManagerXpubs(
+            DefineManagerXpubs::SpendingDelay(Action::Increment),
+        ));
+
+        let mut manager_config = Config::new();
+        manager_step.edit_config(&mut manager_config);
+
+        let mut stakeholder_step = stakeholder::DefineManagerXpubs::new();
+        stakeholder_step.load_context(&Context {
+            number_cosigners: 4,
+            stakeholders_xpubs: vec![
+                STAKEHOLDERS_XPUBS[3].to_string(),
+                STAKEHOLDERS_XPUBS[2].to_string(),
+                STAKEHOLDERS_XPUBS[0].to_string(),
+                STAKEHOLDERS_XPUBS[1].to_string(),
+            ],
+        });
+
+        load_managers_xpubs(
+            &mut stakeholder_step,
+            vec![MANAGERS_XPUBS[1].to_string(), MANAGERS_XPUBS[0].to_string()],
+        );
+        load_cosigners_keys(
+            &mut stakeholder_step,
+            vec![
+                COSIGNERS_KEYS[3].to_string(),
+                COSIGNERS_KEYS[2].to_string(),
+                COSIGNERS_KEYS[0].to_string(),
+                COSIGNERS_KEYS[1].to_string(),
+            ],
+        );
+        stakeholder_step.update(Message::DefineManagerXpubs(
+            DefineManagerXpubs::ManagersTreshold(Action::Increment),
+        ));
+        stakeholder_step.update(Message::DefineManagerXpubs(
+            DefineManagerXpubs::SpendingDelay(Action::Increment),
+        ));
+
+        let mut stakeholder_config = Config::new();
+        stakeholder_step.edit_config(&mut stakeholder_config);
+
+        assert_eq!(
+            manager_config.scripts_config.unvault_descriptor,
+            stakeholder_config.scripts_config.unvault_descriptor,
+        );
+    }
+
+    #[test]
+    fn define_cpfp_descriptor() {
+        let mut cpfp_1_step = DefineCpfpDescriptorStep::new();
+        cpfp_1_step.update(Message::DefineCpfpDescriptor(DefineCpfpDescriptor::AddXpub));
+        cpfp_1_step.update(Message::DefineCpfpDescriptor(
+            DefineCpfpDescriptor::ManagerXpub(
+                0,
+                ParticipantXpub::XpubEdited(MANAGERS_XPUBS[0].to_string()),
+            ),
+        ));
+        cpfp_1_step.update(Message::DefineCpfpDescriptor(DefineCpfpDescriptor::AddXpub));
+        cpfp_1_step.update(Message::DefineCpfpDescriptor(
+            DefineCpfpDescriptor::ManagerXpub(
+                1,
+                ParticipantXpub::XpubEdited(MANAGERS_XPUBS[1].to_string()),
+            ),
+        ));
+
+        let mut cpfp_1_config = Config::new();
+        cpfp_1_step.edit_config(&mut cpfp_1_config);
+
+        let mut cpfp_2_step = DefineCpfpDescriptorStep::new();
+        cpfp_2_step.update(Message::DefineCpfpDescriptor(DefineCpfpDescriptor::AddXpub));
+        cpfp_2_step.update(Message::DefineCpfpDescriptor(
+            DefineCpfpDescriptor::ManagerXpub(
+                0,
+                ParticipantXpub::XpubEdited(MANAGERS_XPUBS[1].to_string()),
+            ),
+        ));
+        cpfp_2_step.update(Message::DefineCpfpDescriptor(DefineCpfpDescriptor::AddXpub));
+        cpfp_2_step.update(Message::DefineCpfpDescriptor(
+            DefineCpfpDescriptor::ManagerXpub(
+                1,
+                ParticipantXpub::XpubEdited(MANAGERS_XPUBS[0].to_string()),
+            ),
+        ));
+
+        let mut cpfp_2_config = Config::new();
+        cpfp_2_step.edit_config(&mut cpfp_2_config);
+    }
+}

--- a/src/installer/step/mod.rs
+++ b/src/installer/step/mod.rs
@@ -30,6 +30,7 @@ pub trait Step {
 }
 
 pub struct Context {
+    pub number_managers: usize,
     pub number_cosigners: usize,
     pub stakeholders_xpubs: Vec<String>,
 }
@@ -37,6 +38,7 @@ pub struct Context {
 impl Context {
     pub fn new() -> Self {
         Self {
+            number_managers: 0,
             number_cosigners: 0,
             stakeholders_xpubs: Vec::new(),
         }

--- a/src/installer/step/mod.rs
+++ b/src/installer/step/mod.rs
@@ -45,6 +45,12 @@ impl Context {
     }
 }
 
+impl Default for Context {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 pub struct Welcome {
     install_button: Button,
 }
@@ -61,6 +67,12 @@ impl Step for Welcome {
     fn update(&mut self, _message: Message) {}
     fn view(&mut self) -> Element<Message> {
         view::welcome(&mut self.install_button)
+    }
+}
+
+impl Default for Welcome {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -97,6 +109,12 @@ impl Step for DefineRole {
             &mut self.stakeholder_manager_button,
             &mut self.scroll,
         )
+    }
+}
+
+impl Default for DefineRole {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -195,6 +213,12 @@ impl Step for DefineCpfpDescriptor {
     }
 }
 
+impl Default for DefineCpfpDescriptor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl From<DefineCpfpDescriptor> for Box<dyn Step> {
     fn from(s: DefineCpfpDescriptor) -> Box<dyn Step> {
         Box::new(s)
@@ -245,6 +269,12 @@ impl Step for DefineCoordinator {
 
     fn view(&mut self) -> Element<Message> {
         self.view.render(&self.host, &self.noise_key, self.warning)
+    }
+}
+
+impl Default for DefineCoordinator {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -321,6 +351,12 @@ impl Step for DefineBitcoind {
     }
 }
 
+impl Default for DefineBitcoind {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl From<DefineBitcoind> for Box<dyn Step> {
     fn from(s: DefineBitcoind) -> Box<dyn Step> {
         Box::new(s)
@@ -369,6 +405,12 @@ impl Step for Final {
     fn view(&mut self) -> Element<Message> {
         self.view
             .render(self.generating, self.success, self.warning.as_ref())
+    }
+}
+
+impl Default for Final {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/installer/step/mod.rs
+++ b/src/installer/step/mod.rs
@@ -559,7 +559,7 @@ mod tests {
         ));
 
         manager_step.update(Message::DefineManagerXpubs(
-            DefineManagerXpubs::ManagersTreshold(Action::Increment),
+            DefineManagerXpubs::ManagersThreshold(Action::Increment),
         ));
         manager_step.update(Message::DefineManagerXpubs(
             DefineManagerXpubs::SpendingDelay(Action::Increment),
@@ -593,7 +593,7 @@ mod tests {
             ],
         );
         stakeholder_step.update(Message::DefineManagerXpubs(
-            DefineManagerXpubs::ManagersTreshold(Action::Increment),
+            DefineManagerXpubs::ManagersThreshold(Action::Increment),
         ));
         stakeholder_step.update(Message::DefineManagerXpubs(
             DefineManagerXpubs::SpendingDelay(Action::Increment),

--- a/src/installer/step/stakeholder.rs
+++ b/src/installer/step/stakeholder.rs
@@ -236,24 +236,24 @@ impl Step for DefineManagerXpubs {
                 message::DefineManagerXpubs::ManagersTreshold(action) => match action {
                     message::Action::Increment => {
                         self.treshold_warning = false;
-                        self.managers_treshold = self.managers_treshold + 1;
+                        self.managers_treshold += 1;
                     }
                     message::Action::Decrement => {
                         self.treshold_warning = false;
                         if self.managers_treshold > 0 {
-                            self.managers_treshold = self.managers_treshold - 1;
+                            self.managers_treshold -= 1;
                         }
                     }
                 },
                 message::DefineManagerXpubs::SpendingDelay(action) => match action {
                     message::Action::Increment => {
-                        self.spending_delay = self.spending_delay + 1;
+                        self.spending_delay += 1;
                         self.spending_delay_warning = false;
                     }
                     message::Action::Decrement => {
                         self.spending_delay_warning = false;
                         if self.spending_delay > 0 {
-                            self.spending_delay = self.spending_delay - 1;
+                            self.spending_delay -= 1;
                         }
                     }
                 },

--- a/src/installer/step/stakeholder.rs
+++ b/src/installer/step/stakeholder.rs
@@ -162,9 +162,9 @@ pub struct DefineManagerXpubs {
 impl DefineManagerXpubs {
     pub fn new() -> Self {
         Self {
-            managers_threshold: 0,
+            managers_threshold: 1,
             threshold_warning: false,
-            spending_delay: 0,
+            spending_delay: 10,
             spending_delay_warning: false,
             manager_xpubs: Vec::new(),
             cosigners: Vec::new(),

--- a/src/installer/step/stakeholder.rs
+++ b/src/installer/step/stakeholder.rs
@@ -110,26 +110,21 @@ impl From<DefineStakeholderXpubs> for Box<dyn Step> {
 }
 
 pub struct DefineManagerXpubs {
+    managers_treshold: u32,
+    spending_delay: u32,
     manager_xpubs: Vec<ParticipantXpub>,
     cosigners: Vec<CosignerKey>,
-
-    add_cosigner_button: Button,
-    add_xpub_button: Button,
-    scroll: scrollable::State,
-    previous_button: Button,
-    save_button: Button,
+    view: view::DefineManagerXpubsAsStakeholderOnly,
 }
 
 impl DefineManagerXpubs {
     pub fn new() -> Self {
         Self {
-            add_xpub_button: Button::new(),
+            managers_treshold: 0,
+            spending_delay: 0,
             manager_xpubs: Vec::new(),
-            scroll: scrollable::State::new(),
-            previous_button: Button::new(),
-            save_button: Button::new(),
             cosigners: Vec::new(),
-            add_cosigner_button: Button::new(),
+            view: view::DefineManagerXpubsAsStakeholderOnly::new(),
         }
     }
 }
@@ -172,14 +167,35 @@ impl Step for DefineManagerXpubs {
                 message::DefineManagerXpubs::AddCosigner => {
                     self.cosigners.push(CosignerKey::new());
                 }
+                message::DefineManagerXpubs::ManagersTreshold(action) => match action {
+                    message::Action::Increment => {
+                        self.managers_treshold = self.managers_treshold + 1;
+                    }
+                    message::Action::Decrement => {
+                        if self.managers_treshold > 0 {
+                            self.managers_treshold = self.managers_treshold - 1;
+                        }
+                    }
+                },
+                message::DefineManagerXpubs::SpendingDelay(action) => match action {
+                    message::Action::Increment => {
+                        self.spending_delay = self.spending_delay + 1;
+                    }
+                    message::Action::Decrement => {
+                        if self.spending_delay > 0 {
+                            self.spending_delay = self.spending_delay - 1;
+                        }
+                    }
+                },
                 _ => {}
             };
         };
     }
 
     fn view(&mut self) -> Element<Message> {
-        view::define_manager_xpubs_as_stakeholder_only(
-            &mut self.add_xpub_button,
+        self.view.render(
+            self.managers_treshold,
+            self.spending_delay,
             self.manager_xpubs
                 .iter_mut()
                 .enumerate()
@@ -191,7 +207,6 @@ impl Step for DefineManagerXpubs {
                     })
                 })
                 .collect(),
-            &mut self.add_cosigner_button,
             self.cosigners
                 .iter_mut()
                 .enumerate()
@@ -203,9 +218,6 @@ impl Step for DefineManagerXpubs {
                     })
                 })
                 .collect(),
-            &mut self.scroll,
-            &mut self.previous_button,
-            &mut self.save_button,
         )
     }
 }

--- a/src/installer/step/stakeholder.rs
+++ b/src/installer/step/stakeholder.rs
@@ -146,8 +146,8 @@ impl From<DefineStakeholderXpubs> for Box<dyn Step> {
 }
 
 pub struct DefineManagerXpubs {
-    managers_treshold: usize,
-    treshold_warning: bool,
+    managers_threshold: usize,
+    threshold_warning: bool,
     spending_delay: u32,
     spending_delay_warning: bool,
     manager_xpubs: Vec<ParticipantXpub>,
@@ -162,8 +162,8 @@ pub struct DefineManagerXpubs {
 impl DefineManagerXpubs {
     pub fn new() -> Self {
         Self {
-            managers_treshold: 0,
-            treshold_warning: false,
+            managers_threshold: 0,
+            threshold_warning: false,
             spending_delay: 0,
             spending_delay_warning: false,
             manager_xpubs: Vec::new(),
@@ -204,15 +204,15 @@ impl Step for DefineManagerXpubs {
                 message::DefineManagerXpubs::AddCosigner => {
                     self.cosigners.push(CosignerKey::new());
                 }
-                message::DefineManagerXpubs::ManagersTreshold(action) => match action {
+                message::DefineManagerXpubs::ManagersThreshold(action) => match action {
                     message::Action::Increment => {
-                        self.treshold_warning = false;
-                        self.managers_treshold += 1;
+                        self.threshold_warning = false;
+                        self.managers_threshold += 1;
                     }
                     message::Action::Decrement => {
-                        self.treshold_warning = false;
-                        if self.managers_treshold > 0 {
-                            self.managers_treshold -= 1;
+                        self.threshold_warning = false;
+                        if self.managers_threshold > 0 {
+                            self.managers_threshold -= 1;
                         }
                     }
                 },
@@ -242,8 +242,8 @@ impl Step for DefineManagerXpubs {
             cosigner.key.valid = DescriptorPublicKey::from_str(&cosigner.key.value).is_ok();
         }
 
-        self.treshold_warning =
-            self.managers_treshold == 0 || self.managers_treshold > self.manager_xpubs.len();
+        self.threshold_warning =
+            self.managers_threshold == 0 || self.managers_threshold > self.manager_xpubs.len();
         self.spending_delay_warning = self.spending_delay == 0;
 
         if self
@@ -251,7 +251,7 @@ impl Step for DefineManagerXpubs {
             .iter()
             .any(|participant| !participant.xpub.valid)
             || self.cosigners.iter().any(|cosigner| !cosigner.key.valid)
-            || self.treshold_warning
+            || self.threshold_warning
             || self.spending_delay_warning
         {
             return false;
@@ -301,7 +301,7 @@ impl Step for DefineManagerXpubs {
         match UnvaultDescriptor::new(
             stakeholders_keys,
             managers_keys,
-            self.managers_treshold,
+            self.managers_threshold,
             cosigners_keys,
             self.spending_delay,
         ) {
@@ -317,8 +317,8 @@ impl Step for DefineManagerXpubs {
 
     fn view(&mut self) -> Element<Message> {
         self.view.render(
-            self.managers_treshold,
-            self.treshold_warning,
+            self.managers_threshold,
+            self.threshold_warning,
             self.spending_delay,
             self.spending_delay_warning,
             self.manager_xpubs

--- a/src/installer/step/stakeholder.rs
+++ b/src/installer/step/stakeholder.rs
@@ -272,7 +272,7 @@ impl Step for DefineManagerXpubs {
 
         managers_xpubs.sort();
 
-        let managers_keys = managers_xpubs
+        let managers_keys: Vec<DescriptorPublicKey> = managers_xpubs
             .into_iter()
             .map(|xpub| DescriptorPublicKey::from_str(&xpub).expect("already checked"))
             .collect();
@@ -304,6 +304,7 @@ impl Step for DefineManagerXpubs {
             .collect();
 
         ctx.number_cosigners = self.cosigners.len();
+        ctx.number_managers = managers_keys.len();
 
         match UnvaultDescriptor::new(
             stakeholders_keys,

--- a/src/installer/step/stakeholder.rs
+++ b/src/installer/step/stakeholder.rs
@@ -150,10 +150,8 @@ impl From<DefineStakeholderXpubs> for Box<dyn Step> {
 }
 
 pub struct DefineManagerXpubs {
-    managers_threshold: usize,
-    threshold_warning: bool,
-    spending_delay: u32,
-    spending_delay_warning: bool,
+    managers_threshold: form::Value<usize>,
+    spending_delay: form::Value<u32>,
     manager_xpubs: Vec<ParticipantXpub>,
     cosigners: Vec<CosignerKey>,
     warning: Option<String>,
@@ -166,10 +164,14 @@ pub struct DefineManagerXpubs {
 impl DefineManagerXpubs {
     pub fn new() -> Self {
         Self {
-            managers_threshold: 1,
-            threshold_warning: false,
-            spending_delay: 10,
-            spending_delay_warning: false,
+            managers_threshold: form::Value {
+                value: 1,
+                valid: true,
+            },
+            spending_delay: form::Value {
+                value: 10,
+                valid: true,
+            },
             manager_xpubs: Vec::new(),
             cosigners: Vec::new(),
             view: view::DefineManagerXpubsAsStakeholderOnly::new(),
@@ -213,25 +215,25 @@ impl Step for DefineManagerXpubs {
                 }
                 message::DefineManagerXpubs::ManagersThreshold(action) => match action {
                     message::Action::Increment => {
-                        self.threshold_warning = false;
-                        self.managers_threshold += 1;
+                        self.managers_threshold.valid = true;
+                        self.managers_threshold.value += 1;
                     }
                     message::Action::Decrement => {
-                        self.threshold_warning = false;
-                        if self.managers_threshold > 0 {
-                            self.managers_threshold -= 1;
+                        self.managers_threshold.valid = true;
+                        if self.managers_threshold.value > 0 {
+                            self.managers_threshold.value -= 1;
                         }
                     }
                 },
                 message::DefineManagerXpubs::SpendingDelay(action) => match action {
                     message::Action::Increment => {
-                        self.spending_delay += 1;
-                        self.spending_delay_warning = false;
+                        self.spending_delay.value += 1;
+                        self.spending_delay.valid = true;
                     }
                     message::Action::Decrement => {
-                        self.spending_delay_warning = false;
-                        if self.spending_delay > 0 {
-                            self.spending_delay -= 1;
+                        self.spending_delay.valid = false;
+                        if self.spending_delay.value > 0 {
+                            self.spending_delay.value -= 1;
                         }
                     }
                 },
@@ -249,17 +251,17 @@ impl Step for DefineManagerXpubs {
             cosigner.key.valid = DescriptorPublicKey::from_str(&cosigner.key.value).is_ok();
         }
 
-        self.threshold_warning =
-            self.managers_threshold == 0 || self.managers_threshold > self.manager_xpubs.len();
-        self.spending_delay_warning = self.spending_delay == 0;
+        self.managers_threshold.valid = self.managers_threshold.value != 0
+            && self.managers_threshold.value <= self.manager_xpubs.len();
+        self.spending_delay.valid = self.spending_delay.value != 0;
 
         if self
             .manager_xpubs
             .iter()
             .any(|participant| !participant.xpub.valid)
             || self.cosigners.iter().any(|cosigner| !cosigner.key.valid)
-            || self.threshold_warning
-            || self.spending_delay_warning
+            || !self.managers_threshold.valid
+            || !self.spending_delay.valid
         {
             return false;
         }
@@ -309,9 +311,9 @@ impl Step for DefineManagerXpubs {
         match UnvaultDescriptor::new(
             stakeholders_keys,
             managers_keys,
-            self.managers_threshold,
+            self.managers_threshold.value,
             cosigners_keys,
-            self.spending_delay,
+            self.spending_delay.value,
         ) {
             Ok(descriptor) => {
                 self.warning = None;
@@ -325,10 +327,8 @@ impl Step for DefineManagerXpubs {
 
     fn view(&mut self) -> Element<Message> {
         self.view.render(
-            self.managers_threshold,
-            self.threshold_warning,
-            self.spending_delay,
-            self.spending_delay_warning,
+            &self.managers_threshold,
+            &self.spending_delay,
             self.manager_xpubs
                 .iter_mut()
                 .enumerate()

--- a/src/installer/step/stakeholder.rs
+++ b/src/installer/step/stakeholder.rs
@@ -143,6 +143,12 @@ impl Step for DefineStakeholderXpubs {
     }
 }
 
+impl Default for DefineStakeholderXpubs {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl From<DefineStakeholderXpubs> for Box<dyn Step> {
     fn from(s: DefineStakeholderXpubs) -> Box<dyn Step> {
         Box::new(s)
@@ -339,6 +345,12 @@ impl Step for DefineManagerXpubs {
     }
 }
 
+impl Default for DefineManagerXpubs {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl From<DefineManagerXpubs> for Box<dyn Step> {
     fn from(s: DefineManagerXpubs) -> Box<dyn Step> {
         Box::new(s)
@@ -389,6 +401,12 @@ impl Step for DefineEmergencyAddress {
     }
 }
 
+impl Default for DefineEmergencyAddress {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl From<DefineEmergencyAddress> for Box<dyn Step> {
     fn from(s: DefineEmergencyAddress) -> Box<dyn Step> {
         Box::new(s)
@@ -436,6 +454,12 @@ impl Watchtower {
             self.warning_host,
             self.warning_noise_key,
         )
+    }
+}
+
+impl Default for Watchtower {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -516,6 +540,12 @@ impl Step for DefineWatchtowers {
                 })
                 .collect(),
         )
+    }
+}
+
+impl Default for DefineWatchtowers {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/installer/step/stakeholder.rs
+++ b/src/installer/step/stakeholder.rs
@@ -1,0 +1,217 @@
+use bitcoin::util::bip32::ExtendedPubKey;
+use iced::{button::State as Button, scrollable, text_input, Element};
+use std::str::FromStr;
+
+use crate::installer::{
+    message::{self, Message},
+    step::{
+        common::{CosignerKey, ParticipantXpub},
+        Step,
+    },
+    view,
+};
+
+pub struct DefineStakeholderXpubs {
+    other_xpubs: Vec<ParticipantXpub>,
+    our_xpub: String,
+    our_xpub_warning: bool,
+
+    our_xpub_input: text_input::State,
+    previous_button: Button,
+    save_button: Button,
+    add_xpub_button: Button,
+    scroll: scrollable::State,
+}
+
+impl DefineStakeholderXpubs {
+    pub fn new() -> Self {
+        Self {
+            our_xpub: "".to_string(),
+            our_xpub_warning: false,
+            other_xpubs: Vec::new(),
+            our_xpub_input: text_input::State::new(),
+            add_xpub_button: Button::new(),
+            scroll: scrollable::State::new(),
+            previous_button: Button::new(),
+            save_button: Button::new(),
+        }
+    }
+}
+
+impl Step for DefineStakeholderXpubs {
+    fn is_correct(&self) -> bool {
+        !self.our_xpub_warning && !self.other_xpubs.iter().any(|xpub| xpub.warning)
+    }
+
+    fn check(&mut self) {
+        for participant in &mut self.other_xpubs {
+            if ExtendedPubKey::from_str(&participant.xpub).is_err() {
+                participant.warning = true;
+            }
+        }
+        if ExtendedPubKey::from_str(&self.our_xpub).is_err() {
+            self.our_xpub_warning = true;
+        }
+    }
+
+    fn update(&mut self, message: Message) {
+        if let Message::DefineStakeholderXpubs(msg) = message {
+            match msg {
+                message::DefineStakeholderXpubs::OurXpubEdited(xpub) => {
+                    self.our_xpub = xpub;
+                    self.our_xpub_warning = false;
+                }
+                message::DefineStakeholderXpubs::StakeholderXpub(
+                    i,
+                    message::ParticipantXpub::Delete,
+                ) => {
+                    self.other_xpubs.remove(i);
+                }
+                message::DefineStakeholderXpubs::StakeholderXpub(i, msg) => {
+                    if let Some(xpub) = self.other_xpubs.get_mut(i) {
+                        xpub.update(msg)
+                    };
+                }
+                message::DefineStakeholderXpubs::AddXpub => {
+                    self.other_xpubs.push(ParticipantXpub::new());
+                }
+            };
+        };
+    }
+
+    fn view(&mut self) -> Element<Message> {
+        return view::define_stakeholder_xpubs_as_stakeholder(
+            &self.our_xpub,
+            &mut self.our_xpub_input,
+            self.our_xpub_warning,
+            &mut self.add_xpub_button,
+            self.other_xpubs
+                .iter_mut()
+                .enumerate()
+                .map(|(i, xpub)| {
+                    xpub.view().map(move |msg| {
+                        Message::DefineStakeholderXpubs(
+                            message::DefineStakeholderXpubs::StakeholderXpub(i, msg),
+                        )
+                    })
+                })
+                .collect(),
+            &mut self.scroll,
+            &mut self.previous_button,
+            &mut self.save_button,
+        );
+    }
+}
+
+impl From<DefineStakeholderXpubs> for Box<dyn Step> {
+    fn from(s: DefineStakeholderXpubs) -> Box<dyn Step> {
+        Box::new(s)
+    }
+}
+
+pub struct DefineManagerXpubs {
+    manager_xpubs: Vec<ParticipantXpub>,
+    cosigners: Vec<CosignerKey>,
+
+    add_cosigner_button: Button,
+    add_xpub_button: Button,
+    scroll: scrollable::State,
+    previous_button: Button,
+    save_button: Button,
+}
+
+impl DefineManagerXpubs {
+    pub fn new() -> Self {
+        Self {
+            add_xpub_button: Button::new(),
+            manager_xpubs: Vec::new(),
+            scroll: scrollable::State::new(),
+            previous_button: Button::new(),
+            save_button: Button::new(),
+            cosigners: Vec::new(),
+            add_cosigner_button: Button::new(),
+        }
+    }
+}
+impl Step for DefineManagerXpubs {
+    fn is_correct(&self) -> bool {
+        self.manager_xpubs.iter().any(|xpub| xpub.warning)
+            || self.cosigners.iter().any(|key| key.warning)
+    }
+
+    fn check(&mut self) {
+        for participant in &mut self.manager_xpubs {
+            if ExtendedPubKey::from_str(&participant.xpub).is_err() {
+                participant.warning = true;
+            }
+        }
+    }
+
+    fn update(&mut self, message: Message) {
+        if let Message::DefineManagerXpubs(msg) = message {
+            match msg {
+                message::DefineManagerXpubs::ManagerXpub(i, message::ParticipantXpub::Delete) => {
+                    self.manager_xpubs.remove(i);
+                }
+                message::DefineManagerXpubs::ManagerXpub(i, msg) => {
+                    if let Some(xpub) = self.manager_xpubs.get_mut(i) {
+                        xpub.update(msg)
+                    };
+                }
+                message::DefineManagerXpubs::AddXpub => {
+                    self.manager_xpubs.push(ParticipantXpub::new());
+                }
+                message::DefineManagerXpubs::CosignerKey(i, message::CosignerKey::Delete) => {
+                    self.cosigners.remove(i);
+                }
+                message::DefineManagerXpubs::CosignerKey(i, msg) => {
+                    if let Some(key) = self.cosigners.get_mut(i) {
+                        key.update(msg)
+                    };
+                }
+                message::DefineManagerXpubs::AddCosigner => {
+                    self.cosigners.push(CosignerKey::new());
+                }
+                _ => {}
+            };
+        };
+    }
+
+    fn view(&mut self) -> Element<Message> {
+        view::define_manager_xpubs_as_stakeholder_only(
+            &mut self.add_xpub_button,
+            self.manager_xpubs
+                .iter_mut()
+                .enumerate()
+                .map(|(i, xpub)| {
+                    xpub.view().map(move |msg| {
+                        Message::DefineManagerXpubs(message::DefineManagerXpubs::ManagerXpub(
+                            i, msg,
+                        ))
+                    })
+                })
+                .collect(),
+            &mut self.add_cosigner_button,
+            self.cosigners
+                .iter_mut()
+                .enumerate()
+                .map(|(i, xpub)| {
+                    xpub.view().map(move |msg| {
+                        Message::DefineManagerXpubs(message::DefineManagerXpubs::CosignerKey(
+                            i, msg,
+                        ))
+                    })
+                })
+                .collect(),
+            &mut self.scroll,
+            &mut self.previous_button,
+            &mut self.save_button,
+        )
+    }
+}
+
+impl From<DefineManagerXpubs> for Box<dyn Step> {
+    fn from(s: DefineManagerXpubs) -> Box<dyn Step> {
+        Box::new(s)
+    }
+}

--- a/src/installer/step/stakeholder.rs
+++ b/src/installer/step/stakeholder.rs
@@ -6,7 +6,7 @@ use crate::installer::{
     message::{self, Message},
     step::{
         common::{CosignerKey, ParticipantXpub},
-        Step,
+        Context, Step,
     },
     view,
 };
@@ -129,6 +129,10 @@ impl DefineManagerXpubs {
     }
 }
 impl Step for DefineManagerXpubs {
+    fn update_context(&self, ctx: &mut Context) {
+        ctx.number_cosigners = self.cosigners.len();
+    }
+
     fn is_correct(&self) -> bool {
         self.manager_xpubs.iter().any(|xpub| xpub.warning)
             || self.cosigners.iter().any(|key| key.warning)

--- a/src/installer/step/stakeholder.rs
+++ b/src/installer/step/stakeholder.rs
@@ -134,8 +134,8 @@ impl Step for DefineManagerXpubs {
     }
 
     fn is_correct(&self) -> bool {
-        self.manager_xpubs.iter().any(|xpub| xpub.warning)
-            || self.cosigners.iter().any(|key| key.warning)
+        !self.manager_xpubs.iter().any(|xpub| xpub.warning)
+            && !self.cosigners.iter().any(|key| key.warning)
     }
 
     fn check(&mut self) {

--- a/src/installer/step/stakeholder.rs
+++ b/src/installer/step/stakeholder.rs
@@ -227,3 +227,47 @@ impl From<DefineManagerXpubs> for Box<dyn Step> {
         Box::new(s)
     }
 }
+
+pub struct DefineEmergencyAddress {
+    address: String,
+    warning: bool,
+
+    view: view::DefineEmergencyAddress,
+}
+
+impl DefineEmergencyAddress {
+    pub fn new() -> Self {
+        Self {
+            address: "".to_string(),
+            warning: false,
+            view: view::DefineEmergencyAddress::new(),
+        }
+    }
+}
+
+impl Step for DefineEmergencyAddress {
+    fn is_correct(&self) -> bool {
+        !self.warning
+    }
+
+    fn check(&mut self) {
+        self.warning = bitcoin::Address::from_str(&self.address).is_err()
+    }
+
+    fn update(&mut self, message: Message) {
+        if let Message::DefineEmergencyAddress(address) = message {
+            self.address = address;
+            self.warning = false;
+        };
+    }
+
+    fn view(&mut self) -> Element<Message> {
+        self.view.render(&self.address, self.warning)
+    }
+}
+
+impl From<DefineEmergencyAddress> for Box<dyn Step> {
+    fn from(s: DefineEmergencyAddress) -> Box<dyn Step> {
+        Box::new(s)
+    }
+}

--- a/src/installer/view.rs
+++ b/src/installer/view.rs
@@ -1,0 +1,460 @@
+use iced::{
+    button::State as Button, scrollable, text_input, Align, Column, Container, Element, Length,
+    Row, TextInput,
+};
+
+use crate::{
+    installer::message::{self, Message},
+    revault::Role,
+    ui::{
+        color,
+        component::{button, image::revault_colored_logo, scroll, text, ContainerBackgroundStyle},
+        icon,
+    },
+};
+
+pub fn welcome(install_button: &mut Button) -> Element<Message> {
+    Container::new(Container::new(
+        Column::new()
+            .push(Container::new(
+                revault_colored_logo()
+                    .width(Length::Units(400))
+                    .height(Length::Fill),
+            ))
+            .push(
+                button::primary(install_button, button::button_content(None, "Install"))
+                    .on_press(Message::Next),
+            )
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .padding(100)
+            .spacing(50)
+            .align_items(Align::Center),
+    ))
+    .center_y()
+    .center_x()
+    .height(Length::Fill)
+    .width(Length::Fill)
+    .into()
+}
+
+pub fn define_role<'a>(
+    stakeholder_button: &'a mut Button,
+    manager_button: &'a mut Button,
+    stakeholder_manager_button: &'a mut Button,
+    scroll: &'a mut scrollable::State,
+) -> Element<'a, Message> {
+    layout_center(
+        scroll,
+        Column::new()
+            .push(
+                Row::new()
+                    .push(
+                        button::white_card_button(
+                            stakeholder_button,
+                            button::button_content(None, "Stakeholder"),
+                        )
+                        .on_press(Message::Role(&Role::STAKEHOLDER_ONLY)),
+                    )
+                    .push(
+                        button::white_card_button(
+                            stakeholder_manager_button,
+                            button::button_content(None, "Stakeholder & Manager"),
+                        )
+                        .on_press(Message::Role(&Role::STAKEHOLDER_AND_MANAGER)),
+                    )
+                    .push(
+                        button::white_card_button(
+                            manager_button,
+                            button::button_content(None, "Manager"),
+                        )
+                        .on_press(Message::Role(&Role::MANAGER_ONLY)),
+                    )
+                    .spacing(20),
+            )
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .padding(100)
+            .spacing(50)
+            .align_items(Align::Center)
+            .into(),
+    )
+}
+
+pub fn participant_xpub<'a>(
+    xpub: &str,
+    xpub_input: &'a mut text_input::State,
+    delete_button: &'a mut Button,
+    warning: bool,
+) -> Element<'a, message::ParticipantXpub> {
+    let mut col = Column::new().push(
+        Row::new()
+            .push(
+                TextInput::new(
+                    xpub_input,
+                    "Xpub",
+                    xpub,
+                    message::ParticipantXpub::XpubEdited,
+                )
+                .size(15)
+                .padding(10),
+            )
+            .push(
+                button::transparent(delete_button, Container::new(icon::trash_icon()))
+                    .on_press(message::ParticipantXpub::Delete),
+            )
+            .spacing(5)
+            .align_items(Align::Center),
+    );
+
+    if warning {
+        col = col.push(text::simple("Please enter a valid xpub").color(color::WARNING))
+    }
+    Container::new(col.spacing(10)).into()
+}
+
+pub fn cosigner_key<'a>(
+    key: &str,
+    key_input: &'a mut text_input::State,
+    delete_button: &'a mut Button,
+    warning: bool,
+) -> Element<'a, message::CosignerKey> {
+    let mut col = Column::new().push(
+        Row::new()
+            .push(
+                TextInput::new(key_input, "Key", key, message::CosignerKey::KeyEdited)
+                    .size(15)
+                    .padding(10),
+            )
+            .push(
+                button::transparent(delete_button, Container::new(icon::trash_icon()))
+                    .on_press(message::CosignerKey::Delete),
+            )
+            .spacing(5)
+            .align_items(Align::Center),
+    );
+
+    if warning {
+        col = col.push(text::simple("Please enter a valid key").color(color::WARNING))
+    }
+    Container::new(col.spacing(10)).into()
+}
+
+pub fn define_stakeholder_xpubs_as_stakeholder<'a>(
+    our_xpub: &str,
+    our_xpub_input: &'a mut text_input::State,
+    our_xpub_warning: bool,
+    add_xpub_button: &'a mut Button,
+    other_xpubs: Vec<Element<'a, Message>>,
+    scroll: &'a mut scrollable::State,
+    previous_button: &'a mut Button,
+    save_button: &'a mut Button,
+) -> Element<'a, Message> {
+    let mut col = Column::new()
+        .push(text::bold(text::simple("Your stakeholder xpub:")))
+        .push(
+            TextInput::new(our_xpub_input, "Your stakeholder xpub", our_xpub, |msg| {
+                Message::DefineStakeholderXpubs(message::DefineStakeholderXpubs::OurXpubEdited(msg))
+            })
+            .size(15)
+            .padding(10),
+        )
+        .spacing(10);
+
+    if our_xpub_warning {
+        col = col.push(text::simple("Please enter a valid xpub").color(color::WARNING));
+    }
+
+    layout(
+        scroll,
+        previous_button,
+        Column::new()
+            .push(text::bold(text::simple("Define stakeholders")).size(50))
+            .push(col)
+            .push(
+                Column::new()
+                    .spacing(10)
+                    .push(text::bold(text::simple("Other stakeholders xpubs:")))
+                    .push(Column::with_children(other_xpubs).spacing(10))
+                    .push(
+                        Container::new(
+                            button::white_card_button(
+                                add_xpub_button,
+                                button::button_content(Some(icon::plus_icon()), "Add stakeholder"),
+                            )
+                            .on_press(Message::DefineStakeholderXpubs(
+                                message::DefineStakeholderXpubs::AddXpub,
+                            )),
+                        )
+                        .width(Length::Fill),
+                    ),
+            )
+            .push(
+                Row::new()
+                    .push(
+                        button::primary(save_button, button::button_content(None, "Save"))
+                            .on_press(Message::Next),
+                    )
+                    .align_items(Align::Center)
+                    .spacing(20),
+            )
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .padding(100)
+            .spacing(50)
+            .align_items(Align::Center)
+            .into(),
+    )
+}
+
+pub fn define_stakeholder_xpubs_as_manager_only<'a>(
+    add_xpub_button: &'a mut Button,
+    stakeholder_xpubs: Vec<Element<'a, Message>>,
+    scroll: &'a mut scrollable::State,
+    previous_button: &'a mut Button,
+    save_button: &'a mut Button,
+) -> Element<'a, Message> {
+    let mut row = Row::new().align_items(Align::Center).spacing(20);
+    if stakeholder_xpubs.is_empty() {
+        row = row.push(button::primary(
+            save_button,
+            button::button_content(None, "Save"),
+        ));
+    } else {
+        row = row.push(
+            button::primary(save_button, button::button_content(None, "Save"))
+                .on_press(Message::Next),
+        );
+    }
+
+    layout(
+        scroll,
+        previous_button,
+        Column::new()
+            .push(text::bold(text::simple("Define stakeholders")).size(50))
+            .push(
+                Column::new()
+                    .spacing(10)
+                    .push(text::bold(text::simple("Stakeholders xpubs:")))
+                    .push(Column::with_children(stakeholder_xpubs).spacing(10))
+                    .push(
+                        Container::new(
+                            button::white_card_button(
+                                add_xpub_button,
+                                button::button_content(Some(icon::plus_icon()), "Add stakeholder"),
+                            )
+                            .on_press(Message::DefineStakeholderXpubs(
+                                message::DefineStakeholderXpubs::AddXpub,
+                            )),
+                        )
+                        .width(Length::Fill),
+                    ),
+            )
+            .push(row)
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .padding(100)
+            .spacing(50)
+            .align_items(Align::Center)
+            .into(),
+    )
+}
+
+pub fn define_manager_xpubs_as_manager<'a>(
+    our_xpub: &str,
+    our_xpub_input: &'a mut text_input::State,
+    our_xpub_warning: bool,
+    add_xpub_button: &'a mut Button,
+    other_xpubs: Vec<Element<'a, Message>>,
+    add_cosigner_button: &'a mut Button,
+    cosigners: Vec<Element<'a, Message>>,
+    scroll: &'a mut scrollable::State,
+    previous_button: &'a mut Button,
+    save_button: &'a mut Button,
+) -> Element<'a, Message> {
+    let mut col = Column::new()
+        .push(text::bold(text::simple("Your manager xpub:")))
+        .push(
+            TextInput::new(our_xpub_input, "Your manager xpub", our_xpub, |msg| {
+                Message::DefineManagerXpubs(message::DefineManagerXpubs::OurXpubEdited(msg))
+            })
+            .size(15)
+            .padding(10),
+        )
+        .spacing(10);
+
+    if our_xpub_warning {
+        col = col.push(text::simple("Please enter a valid xpub").color(color::WARNING));
+    }
+
+    layout(
+        scroll,
+        previous_button,
+        Column::new()
+            .push(text::bold(text::simple("Define managers")).size(50))
+            .push(col)
+            .push(
+                Column::new()
+                    .push(text::bold(text::simple("Other Managers xpubs:")))
+                    .push(Column::with_children(other_xpubs).spacing(10))
+                    .push(
+                        Container::new(
+                            button::white_card_button(
+                                add_xpub_button,
+                                button::button_content(Some(icon::plus_icon()), "Add manager"),
+                            )
+                            .on_press(Message::DefineManagerXpubs(
+                                message::DefineManagerXpubs::AddXpub,
+                            )),
+                        )
+                        .width(Length::Fill),
+                    )
+                    .spacing(10),
+            )
+            .push(
+                Column::new()
+                    .push(text::bold(text::simple("Cosigners keys:")))
+                    .push(Column::with_children(cosigners).spacing(10))
+                    .push(
+                        Container::new(
+                            button::white_card_button(
+                                add_cosigner_button,
+                                button::button_content(Some(icon::plus_icon()), "Add cosigner key"),
+                            )
+                            .on_press(Message::DefineManagerXpubs(
+                                message::DefineManagerXpubs::AddCosigner,
+                            )),
+                        )
+                        .width(Length::Fill),
+                    )
+                    .spacing(10),
+            )
+            .push(
+                Row::new()
+                    .push(
+                        button::primary(save_button, button::button_content(None, "Save"))
+                            .on_press(Message::Next),
+                    )
+                    .align_items(Align::Center)
+                    .spacing(20),
+            )
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .padding(100)
+            .spacing(50)
+            .align_items(Align::Center)
+            .into(),
+    )
+}
+
+pub fn define_manager_xpubs_as_stakeholder_only<'a>(
+    add_xpub_button: &'a mut Button,
+    manager_xpubs: Vec<Element<'a, Message>>,
+    add_cosigner_button: &'a mut Button,
+    cosigners: Vec<Element<'a, Message>>,
+    scroll: &'a mut scrollable::State,
+    previous_button: &'a mut Button,
+    save_button: &'a mut Button,
+) -> Element<'a, Message> {
+    let mut row = Row::new().align_items(Align::Center).spacing(20);
+    if manager_xpubs.is_empty() {
+        row = row.push(button::primary(
+            save_button,
+            button::button_content(None, "Save"),
+        ));
+    } else {
+        row = row.push(
+            button::primary(save_button, button::button_content(None, "Save"))
+                .on_press(Message::Next),
+        );
+    }
+
+    layout(
+        scroll,
+        previous_button,
+        Column::new()
+            .push(text::bold(text::simple("Define managers")).size(50))
+            .push(
+                Column::new()
+                    .spacing(10)
+                    .push(text::bold(text::simple("Managers xpubs:")))
+                    .push(Column::with_children(manager_xpubs).spacing(10))
+                    .push(
+                        Container::new(
+                            button::white_card_button(
+                                add_xpub_button,
+                                button::button_content(Some(icon::plus_icon()), "Add manager"),
+                            )
+                            .on_press(Message::DefineManagerXpubs(
+                                message::DefineManagerXpubs::AddXpub,
+                            )),
+                        )
+                        .width(Length::Fill),
+                    ),
+            )
+            .push(
+                Column::new()
+                    .spacing(10)
+                    .push(text::bold(text::simple("Cosigners keys:")))
+                    .push(Column::with_children(cosigners).spacing(10))
+                    .push(
+                        Container::new(
+                            button::white_card_button(
+                                add_cosigner_button,
+                                button::button_content(Some(icon::plus_icon()), "Add cosigner"),
+                            )
+                            .on_press(Message::DefineManagerXpubs(
+                                message::DefineManagerXpubs::AddCosigner,
+                            )),
+                        )
+                        .width(Length::Fill),
+                    ),
+            )
+            .push(row)
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .padding(100)
+            .spacing(50)
+            .align_items(Align::Center)
+            .into(),
+    )
+}
+
+fn layout<'a>(
+    scroll_state: &'a mut scrollable::State,
+    previous_button: &'a mut Button,
+    content: Element<'a, Message>,
+) -> Element<'a, Message> {
+    Container::new(scroll(
+        scroll_state,
+        Container::new(
+            Column::new()
+                .push(
+                    button::transparent(
+                        previous_button,
+                        button::button_content(None, "< Previous"),
+                    )
+                    .on_press(Message::Previous),
+                )
+                .push(Container::new(content).width(Length::Fill).center_x()),
+        ),
+    ))
+    .style(ContainerBackgroundStyle)
+    .center_x()
+    .height(Length::Fill)
+    .width(Length::Fill)
+    .into()
+}
+
+fn layout_center<'a>(
+    scroll_state: &'a mut scrollable::State,
+    content: Element<'a, Message>,
+) -> Element<'a, Message> {
+    Container::new(scroll(scroll_state, Container::new(content)))
+        .style(ContainerBackgroundStyle)
+        .center_y()
+        .center_x()
+        .height(Length::Fill)
+        .width(Length::Fill)
+        .into()
+}

--- a/src/installer/view.rs
+++ b/src/installer/view.rs
@@ -833,6 +833,127 @@ impl DefineEmergencyAddress {
     }
 }
 
+pub struct Watchtower {
+    noise_key_input: text_input::State,
+    host_input: text_input::State,
+    delete_button: Button,
+}
+
+impl Watchtower {
+    pub fn new() -> Self {
+        Self {
+            noise_key_input: text_input::State::new(),
+            host_input: text_input::State::new(),
+            delete_button: Button::new(),
+        }
+    }
+    pub fn render(
+        &mut self,
+        host: &str,
+        noise_key: &str,
+        warning_host: bool,
+        warning_noise_key: bool,
+    ) -> Element<message::DefineWatchtower> {
+        let mut col = Column::new().push(
+            Row::new()
+                .push(
+                    TextInput::new(
+                        &mut self.host_input,
+                        "Host",
+                        host,
+                        message::DefineWatchtower::HostEdited,
+                    )
+                    .size(15)
+                    .padding(10),
+                )
+                .push(
+                    TextInput::new(
+                        &mut self.noise_key_input,
+                        "Noise key",
+                        noise_key,
+                        message::DefineWatchtower::NoiseKeyEdited,
+                    )
+                    .size(15)
+                    .padding(10),
+                )
+                .push(
+                    button::transparent(
+                        &mut self.delete_button,
+                        Container::new(icon::trash_icon()),
+                    )
+                    .on_press(message::DefineWatchtower::Delete),
+                )
+                .spacing(5)
+                .align_items(Align::Center),
+        );
+
+        if warning_host {
+            col = col.push(text::simple("Please enter a valid host").color(color::WARNING))
+        }
+        if warning_noise_key {
+            col = col.push(text::simple("Please enter a valid noise_key").color(color::WARNING))
+        }
+        Container::new(col.spacing(10)).into()
+    }
+}
+
+pub struct DefineWatchtowers {
+    add_watchtower_button: Button,
+    scroll: scrollable::State,
+    previous_button: Button,
+    save_button: Button,
+}
+
+impl DefineWatchtowers {
+    pub fn new() -> Self {
+        Self {
+            add_watchtower_button: Button::new(),
+            scroll: scrollable::State::new(),
+            previous_button: Button::new(),
+            save_button: Button::new(),
+        }
+    }
+    pub fn render<'a>(
+        &'a mut self,
+        watchtowers: Vec<Element<'a, Message>>,
+    ) -> Element<'a, Message> {
+        layout(
+            &mut self.scroll,
+            &mut self.previous_button,
+            Column::new()
+                .push(text::bold(text::simple("Define your watchtowers")).size(50))
+                .push(
+                    Column::new()
+                        .push(
+                            Container::new(text::bold(text::simple("Your watchtowers:")))
+                                .width(Length::Fill),
+                        )
+                        .push(Column::with_children(watchtowers).spacing(10))
+                        .push(
+                            button::transparent(
+                                &mut self.add_watchtower_button,
+                                button::button_content(Some(icon::plus_icon()), "Add a watchtower"),
+                            )
+                            .on_press(Message::DefineWatchtowers(
+                                message::DefineWatchtowers::AddWatchtower,
+                            )),
+                        )
+                        .spacing(10),
+                )
+                .push(
+                    button::primary(&mut self.save_button, button::button_content(None, "Save"))
+                        .on_press(Message::Next),
+                )
+                .width(Length::Fill)
+                .height(Length::Fill)
+                .padding(100)
+                .spacing(50)
+                .align_items(Align::Center)
+                .into(),
+        )
+    }
+}
+
 fn layout<'a>(
     scroll_state: &'a mut scrollable::State,
     previous_button: &'a mut Button,

--- a/src/installer/view.rs
+++ b/src/installer/view.rs
@@ -152,6 +152,7 @@ pub fn define_stakeholder_xpubs_as_stakeholder<'a>(
     scroll: &'a mut scrollable::State,
     previous_button: &'a mut Button,
     save_button: &'a mut Button,
+    warning: Option<&String>,
 ) -> Element<'a, Message> {
     let mut col = Column::new()
         .push(text::bold(text::simple("Your stakeholder xpub:")))
@@ -168,39 +169,46 @@ pub fn define_stakeholder_xpubs_as_stakeholder<'a>(
         col = col.push(text::simple("Please enter a valid xpub").color(color::WARNING));
     }
 
+    let mut content = Column::new()
+        .push(text::bold(text::simple("Define stakeholders")).size(50))
+        .push(col)
+        .push(
+            Column::new()
+                .spacing(10)
+                .push(text::bold(text::simple("Other stakeholders xpubs:")))
+                .push(Column::with_children(other_xpubs).spacing(10))
+                .push(
+                    Container::new(
+                        button::white_card_button(
+                            add_xpub_button,
+                            button::button_content(Some(icon::plus_icon()), "Add stakeholder"),
+                        )
+                        .on_press(Message::DefineStakeholderXpubs(
+                            message::DefineStakeholderXpubs::AddXpub,
+                        )),
+                    )
+                    .width(Length::Fill),
+                ),
+        )
+        .push(
+            Row::new()
+                .push(
+                    button::primary(save_button, button::button_content(None, "Next"))
+                        .on_press(Message::Next)
+                        .min_width(200),
+                )
+                .align_items(Align::Center)
+                .spacing(20),
+        );
+
+    if let Some(error) = warning {
+        content = content.push(card::alert_warning(Container::new(text::simple(&error))));
+    }
+
     layout(
         scroll,
         previous_button,
-        Column::new()
-            .push(text::bold(text::simple("Define stakeholders")).size(50))
-            .push(col)
-            .push(
-                Column::new()
-                    .spacing(10)
-                    .push(text::bold(text::simple("Other stakeholders xpubs:")))
-                    .push(Column::with_children(other_xpubs).spacing(10))
-                    .push(
-                        Container::new(
-                            button::white_card_button(
-                                add_xpub_button,
-                                button::button_content(Some(icon::plus_icon()), "Add stakeholder"),
-                            )
-                            .on_press(Message::DefineStakeholderXpubs(
-                                message::DefineStakeholderXpubs::AddXpub,
-                            )),
-                        )
-                        .width(Length::Fill),
-                    ),
-            )
-            .push(
-                Row::new()
-                    .push(
-                        button::primary(save_button, button::button_content(None, "Next"))
-                            .on_press(Message::Next),
-                    )
-                    .align_items(Align::Center)
-                    .spacing(20),
-            )
+        content
             .width(Length::Fill)
             .height(Length::Fill)
             .padding(100)
@@ -216,6 +224,7 @@ pub fn define_stakeholder_xpubs_as_manager_only<'a>(
     scroll: &'a mut scrollable::State,
     previous_button: &'a mut Button,
     save_button: &'a mut Button,
+    warning: Option<&String>,
 ) -> Element<'a, Message> {
     let mut row = Row::new().align_items(Align::Center).spacing(20);
     if stakeholder_xpubs.is_empty() {
@@ -230,29 +239,33 @@ pub fn define_stakeholder_xpubs_as_manager_only<'a>(
         );
     }
 
+    let mut content = Column::new()
+        .spacing(10)
+        .push(text::bold(text::simple("Stakeholders xpubs:")))
+        .push(Column::with_children(stakeholder_xpubs).spacing(10))
+        .push(
+            Container::new(
+                button::white_card_button(
+                    add_xpub_button,
+                    button::button_content(Some(icon::plus_icon()), "Add stakeholder"),
+                )
+                .on_press(Message::DefineStakeholderXpubs(
+                    message::DefineStakeholderXpubs::AddXpub,
+                )),
+            )
+            .width(Length::Fill),
+        );
+
+    if let Some(error) = warning {
+        content = content.push(card::alert_warning(Container::new(text::simple(&error))));
+    }
+
     layout(
         scroll,
         previous_button,
         Column::new()
             .push(text::bold(text::simple("Define stakeholders")).size(50))
-            .push(
-                Column::new()
-                    .spacing(10)
-                    .push(text::bold(text::simple("Stakeholders xpubs:")))
-                    .push(Column::with_children(stakeholder_xpubs).spacing(10))
-                    .push(
-                        Container::new(
-                            button::white_card_button(
-                                add_xpub_button,
-                                button::button_content(Some(icon::plus_icon()), "Add stakeholder"),
-                            )
-                            .on_press(Message::DefineStakeholderXpubs(
-                                message::DefineStakeholderXpubs::AddXpub,
-                            )),
-                        )
-                        .width(Length::Fill),
-                    ),
-            )
+            .push(content)
             .push(row)
             .width(Length::Fill)
             .height(Length::Fill)
@@ -425,6 +438,7 @@ impl DefineManagerXpubsAsManager {
         our_xpub_warning: bool,
         other_xpubs: Vec<Element<'a, Message>>,
         cosigners: Vec<Element<'a, Message>>,
+        warning: Option<&String>,
     ) -> Element<'a, Message> {
         let mut manager_xpub_col = Column::new()
             .push(text::bold(text::simple("Your manager xpub:")))
@@ -447,88 +461,87 @@ impl DefineManagerXpubsAsManager {
                 .push(text::simple("Please enter a valid xpub").color(color::WARNING));
         }
 
+        let mut content = Column::new()
+            .push(text::bold(text::simple("Define managers")).size(50))
+            .push(
+                Row::new()
+                    .push(
+                        Container::new(
+                            self.managers_treshold
+                                .render(managers_treshold, treshold_warning),
+                        )
+                        .width(Length::FillPortion(1))
+                        .align_x(Align::Center),
+                    )
+                    .push(
+                        Container::new(
+                            self.spending_delay
+                                .render(spending_delay, spending_delay_warning),
+                        )
+                        .width(Length::FillPortion(1))
+                        .align_x(Align::Center),
+                    )
+                    .width(Length::Fill),
+            )
+            .push(manager_xpub_col)
+            .push(
+                Column::new()
+                    .push(text::bold(text::simple("Other Managers xpubs:")))
+                    .push(Column::with_children(other_xpubs).spacing(10))
+                    .push(
+                        Container::new(
+                            button::white_card_button(
+                                &mut self.add_xpub_button,
+                                button::button_content(Some(icon::plus_icon()), "Add manager"),
+                            )
+                            .on_press(Message::DefineManagerXpubs(
+                                message::DefineManagerXpubs::AddXpub,
+                            )),
+                        )
+                        .width(Length::Fill),
+                    )
+                    .spacing(10),
+            )
+            .push(
+                Column::new()
+                    .push(text::bold(text::simple("Cosigners keys:")))
+                    .push(Column::with_children(cosigners).spacing(10))
+                    .push(
+                        Container::new(
+                            button::white_card_button(
+                                &mut self.add_cosigner_button,
+                                button::button_content(Some(icon::plus_icon()), "Add cosigner key"),
+                            )
+                            .on_press(Message::DefineManagerXpubs(
+                                message::DefineManagerXpubs::AddCosigner,
+                            )),
+                        )
+                        .width(Length::Fill),
+                    )
+                    .spacing(10),
+            )
+            .push(
+                Row::new()
+                    .push(
+                        button::primary(
+                            &mut self.save_button,
+                            button::button_content(None, "Next"),
+                        )
+                        .on_press(Message::Next)
+                        .min_width(200),
+                    )
+                    .align_items(Align::Center)
+                    .spacing(20),
+            );
+
+        if let Some(error) = warning {
+            content = content.push(card::alert_warning(Container::new(text::simple(&error))));
+        }
+
         layout(
             &mut self.scroll,
             &mut self.previous_button,
-            Column::new()
-                .push(text::bold(text::simple("Define managers")).size(50))
-                .push(
-                    Row::new()
-                        .push(
-                            Container::new(
-                                self.managers_treshold
-                                    .render(managers_treshold, treshold_warning),
-                            )
-                            .width(Length::FillPortion(1))
-                            .align_x(Align::Center),
-                        )
-                        .push(
-                            Container::new(
-                                self.spending_delay
-                                    .render(spending_delay, spending_delay_warning),
-                            )
-                            .width(Length::FillPortion(1))
-                            .align_x(Align::Center),
-                        )
-                        .width(Length::Fill),
-                )
-                .push(manager_xpub_col)
-                .push(
-                    Column::new()
-                        .push(text::bold(text::simple("Other Managers xpubs:")))
-                        .push(Column::with_children(other_xpubs).spacing(10))
-                        .push(
-                            Container::new(
-                                button::white_card_button(
-                                    &mut self.add_xpub_button,
-                                    button::button_content(Some(icon::plus_icon()), "Add manager"),
-                                )
-                                .on_press(
-                                    Message::DefineManagerXpubs(
-                                        message::DefineManagerXpubs::AddXpub,
-                                    ),
-                                ),
-                            )
-                            .width(Length::Fill),
-                        )
-                        .spacing(10),
-                )
-                .push(
-                    Column::new()
-                        .push(text::bold(text::simple("Cosigners keys:")))
-                        .push(Column::with_children(cosigners).spacing(10))
-                        .push(
-                            Container::new(
-                                button::white_card_button(
-                                    &mut self.add_cosigner_button,
-                                    button::button_content(
-                                        Some(icon::plus_icon()),
-                                        "Add cosigner key",
-                                    ),
-                                )
-                                .on_press(
-                                    Message::DefineManagerXpubs(
-                                        message::DefineManagerXpubs::AddCosigner,
-                                    ),
-                                ),
-                            )
-                            .width(Length::Fill),
-                        )
-                        .spacing(10),
-                )
-                .push(
-                    Row::new()
-                        .push(
-                            button::primary(
-                                &mut self.save_button,
-                                button::button_content(None, "Next"),
-                            )
-                            .on_press(Message::Next)
-                            .min_width(200),
-                        )
-                        .align_items(Align::Center)
-                        .spacing(20),
-                )
+            content
                 .width(Length::Fill)
                 .height(Length::Fill)
                 .padding(100)
@@ -569,6 +582,7 @@ impl DefineManagerXpubsAsStakeholderOnly {
         spending_delay_warning: bool,
         manager_xpubs: Vec<Element<'a, Message>>,
         cosigners: Vec<Element<'a, Message>>,
+        warning: Option<&String>,
     ) -> Element<'a, Message> {
         let mut row = Row::new().align_items(Align::Center).spacing(20);
         if manager_xpubs.is_empty() {
@@ -587,78 +601,78 @@ impl DefineManagerXpubsAsStakeholderOnly {
             );
         }
 
+        let mut content = Column::new()
+            .push(text::bold(text::simple("Define managers")).size(50))
+            .push(
+                Row::new()
+                    .push(
+                        Container::new(
+                            self.managers_treshold
+                                .render(managers_treshold, treshold_warning),
+                        )
+                        .width(Length::FillPortion(1))
+                        .align_x(Align::Center),
+                    )
+                    .push(
+                        Container::new(
+                            self.spending_delay
+                                .render(spending_delay, spending_delay_warning),
+                        )
+                        .width(Length::FillPortion(1))
+                        .align_x(Align::Center),
+                    )
+                    .width(Length::Fill),
+            )
+            .push(
+                Column::new()
+                    .spacing(10)
+                    .push(text::bold(text::simple("Managers xpubs:")))
+                    .push(Column::with_children(manager_xpubs).spacing(10))
+                    .push(
+                        Container::new(
+                            button::white_card_button(
+                                &mut self.add_xpub_button,
+                                button::button_content(Some(icon::plus_icon()), "Add manager"),
+                            )
+                            .on_press(Message::DefineManagerXpubs(
+                                message::DefineManagerXpubs::AddXpub,
+                            )),
+                        )
+                        .width(Length::Fill),
+                    ),
+            )
+            .push(
+                Column::new()
+                    .spacing(10)
+                    .push(text::bold(text::simple("Cosigners keys:")))
+                    .push(Column::with_children(cosigners).spacing(10))
+                    .push(
+                        Container::new(
+                            button::white_card_button(
+                                &mut self.add_cosigner_button,
+                                button::button_content(Some(icon::plus_icon()), "Add cosigner"),
+                            )
+                            .on_press(Message::DefineManagerXpubs(
+                                message::DefineManagerXpubs::AddCosigner,
+                            )),
+                        )
+                        .width(Length::Fill),
+                    ),
+            )
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .padding(100)
+            .spacing(50)
+            .align_items(Align::Center);
+
+        if let Some(error) = warning {
+            content = content.push(card::alert_warning(Container::new(text::simple(&error))));
+        }
+
         layout(
             &mut self.scroll,
             &mut self.previous_button,
-            Column::new()
-                .push(text::bold(text::simple("Define managers")).size(50))
-                .push(
-                    Row::new()
-                        .push(
-                            Container::new(
-                                self.managers_treshold
-                                    .render(managers_treshold, treshold_warning),
-                            )
-                            .width(Length::FillPortion(1))
-                            .align_x(Align::Center),
-                        )
-                        .push(
-                            Container::new(
-                                self.spending_delay
-                                    .render(spending_delay, spending_delay_warning),
-                            )
-                            .width(Length::FillPortion(1))
-                            .align_x(Align::Center),
-                        )
-                        .width(Length::Fill),
-                )
-                .push(
-                    Column::new()
-                        .spacing(10)
-                        .push(text::bold(text::simple("Managers xpubs:")))
-                        .push(Column::with_children(manager_xpubs).spacing(10))
-                        .push(
-                            Container::new(
-                                button::white_card_button(
-                                    &mut self.add_xpub_button,
-                                    button::button_content(Some(icon::plus_icon()), "Add manager"),
-                                )
-                                .on_press(
-                                    Message::DefineManagerXpubs(
-                                        message::DefineManagerXpubs::AddXpub,
-                                    ),
-                                ),
-                            )
-                            .width(Length::Fill),
-                        ),
-                )
-                .push(
-                    Column::new()
-                        .spacing(10)
-                        .push(text::bold(text::simple("Cosigners keys:")))
-                        .push(Column::with_children(cosigners).spacing(10))
-                        .push(
-                            Container::new(
-                                button::white_card_button(
-                                    &mut self.add_cosigner_button,
-                                    button::button_content(Some(icon::plus_icon()), "Add cosigner"),
-                                )
-                                .on_press(
-                                    Message::DefineManagerXpubs(
-                                        message::DefineManagerXpubs::AddCosigner,
-                                    ),
-                                ),
-                            )
-                            .width(Length::Fill),
-                        ),
-                )
-                .push(row)
-                .width(Length::Fill)
-                .height(Length::Fill)
-                .padding(100)
-                .spacing(50)
-                .align_items(Align::Center)
-                .into(),
+            content.push(row).into(),
         )
     }
 }
@@ -669,6 +683,7 @@ pub fn define_cpfp_descriptor<'a>(
     scroll: &'a mut scrollable::State,
     previous_button: &'a mut Button,
     save_button: &'a mut Button,
+    warning: Option<&String>,
 ) -> Element<'a, Message> {
     let mut row = Row::new().align_items(Align::Center).spacing(20);
     if manager_xpubs.is_empty() {
@@ -683,29 +698,33 @@ pub fn define_cpfp_descriptor<'a>(
         );
     }
 
+    let mut content = Column::new()
+        .spacing(10)
+        .push(text::bold(text::simple("Managers xpubs:")))
+        .push(Column::with_children(manager_xpubs).spacing(10))
+        .push(
+            Container::new(
+                button::white_card_button(
+                    add_xpub_button,
+                    button::button_content(Some(icon::plus_icon()), "Add manager"),
+                )
+                .on_press(Message::DefineCpfpDescriptor(
+                    message::DefineCpfpDescriptor::AddXpub,
+                )),
+            )
+            .width(Length::Fill),
+        );
+
+    if let Some(error) = warning {
+        content = content.push(card::alert_warning(Container::new(text::simple(&error))));
+    }
+
     layout(
         scroll,
         previous_button,
         Column::new()
             .push(text::bold(text::simple("Define fee bumping managers")).size(50))
-            .push(
-                Column::new()
-                    .spacing(10)
-                    .push(text::bold(text::simple("Managers xpubs:")))
-                    .push(Column::with_children(manager_xpubs).spacing(10))
-                    .push(
-                        Container::new(
-                            button::white_card_button(
-                                add_xpub_button,
-                                button::button_content(Some(icon::plus_icon()), "Add manager"),
-                            )
-                            .on_press(Message::DefineCpfpDescriptor(
-                                message::DefineCpfpDescriptor::AddXpub,
-                            )),
-                        )
-                        .width(Length::Fill),
-                    ),
-            )
+            .push(content)
             .push(row)
             .width(Length::Fill)
             .height(Length::Fill)
@@ -1059,10 +1078,7 @@ impl DefineCosigners {
             save_button: Button::new(),
         }
     }
-    pub fn render<'a>(
-        &'a mut self,
-        watchtowers: Vec<Element<'a, Message>>,
-    ) -> Element<'a, Message> {
+    pub fn render<'a>(&'a mut self, cosigners: Vec<Element<'a, Message>>) -> Element<'a, Message> {
         layout(
             &mut self.scroll,
             &mut self.previous_button,
@@ -1074,7 +1090,7 @@ impl DefineCosigners {
                             Container::new(text::bold(text::simple("The cosigners:")))
                                 .width(Length::Fill),
                         )
-                        .push(Column::with_children(watchtowers).spacing(10))
+                        .push(Column::with_children(cosigners).spacing(10))
                         .spacing(10),
                 )
                 .push(

--- a/src/installer/view.rs
+++ b/src/installer/view.rs
@@ -888,11 +888,11 @@ impl DefineEmergencyAddress {
             );
         }
         let col = Column::new()
-            .push(text::bold(text::simple("address:")))
+            .push(text::bold(text::simple("Address:")))
             .push(
                 form::Form::new(
                     &mut self.address_input,
-                    "address",
+                    "",
                     address,
                     Message::DefineEmergencyAddress,
                 )

--- a/src/installer/view.rs
+++ b/src/installer/view.rs
@@ -25,7 +25,8 @@ pub fn welcome(install_button: &mut Button) -> Element<Message> {
             ))
             .push(
                 button::primary(install_button, button::button_content(None, "Install"))
-                    .on_press(Message::Next),
+                    .on_press(Message::Next)
+                    .min_width(200),
             )
             .width(Length::Fill)
             .height(Length::Fill)
@@ -194,7 +195,7 @@ pub fn define_stakeholder_xpubs_as_stakeholder<'a>(
             .push(
                 Row::new()
                     .push(
-                        button::primary(save_button, button::button_content(None, "Save"))
+                        button::primary(save_button, button::button_content(None, "Next"))
                             .on_press(Message::Next),
                     )
                     .align_items(Align::Center)
@@ -218,14 +219,14 @@ pub fn define_stakeholder_xpubs_as_manager_only<'a>(
 ) -> Element<'a, Message> {
     let mut row = Row::new().align_items(Align::Center).spacing(20);
     if stakeholder_xpubs.is_empty() {
-        row = row.push(button::primary(
-            save_button,
-            button::button_content(None, "Save"),
-        ));
+        row = row.push(
+            button::primary(save_button, button::button_content(None, "Next")).min_width(200),
+        );
     } else {
         row = row.push(
-            button::primary(save_button, button::button_content(None, "Save"))
-                .on_press(Message::Next),
+            button::primary(save_button, button::button_content(None, "Next"))
+                .on_press(Message::Next)
+                .min_width(200),
         );
     }
 
@@ -520,9 +521,10 @@ impl DefineManagerXpubsAsManager {
                         .push(
                             button::primary(
                                 &mut self.save_button,
-                                button::button_content(None, "Save"),
+                                button::button_content(None, "Next"),
                             )
-                            .on_press(Message::Next),
+                            .on_press(Message::Next)
+                            .min_width(200),
                         )
                         .align_items(Align::Center)
                         .spacing(20),
@@ -570,14 +572,18 @@ impl DefineManagerXpubsAsStakeholderOnly {
     ) -> Element<'a, Message> {
         let mut row = Row::new().align_items(Align::Center).spacing(20);
         if manager_xpubs.is_empty() {
-            row = row.push(button::primary(
-                &mut self.save_button,
-                button::button_content(None, "Save"),
-            ));
+            row = row.push(
+                button::primary(&mut self.save_button, button::button_content(None, "Next"))
+                    .min_width(200),
+            );
         } else {
             row = row.push(
-                button::primary(&mut self.save_button, button::button_content(None, "Save"))
-                    .on_press(Message::Next),
+                button::primary(
+                    &mut self.save_button,
+                    button::button_content(None, "Next").width(Length::Fill),
+                )
+                .on_press(Message::Next)
+                .min_width(200),
             );
         }
 
@@ -666,14 +672,14 @@ pub fn define_cpfp_descriptor<'a>(
 ) -> Element<'a, Message> {
     let mut row = Row::new().align_items(Align::Center).spacing(20);
     if manager_xpubs.is_empty() {
-        row = row.push(button::primary(
-            save_button,
-            button::button_content(None, "Save"),
-        ));
+        row = row.push(
+            button::primary(save_button, button::button_content(None, "Next")).min_width(200),
+        );
     } else {
         row = row.push(
-            button::primary(save_button, button::button_content(None, "Save"))
-                .on_press(Message::Next),
+            button::primary(save_button, button::button_content(None, "Next"))
+                .on_press(Message::Next)
+                .min_width(200),
         );
     }
 
@@ -736,14 +742,15 @@ impl DefineCoordinator {
     ) -> Element<'a, Message> {
         let mut row = Row::new().align_items(Align::Center).spacing(20);
         if warning {
-            row = row.push(button::primary(
-                &mut self.save_button,
-                button::button_content(None, "Save"),
-            ));
+            row = row.push(
+                button::primary(&mut self.save_button, button::button_content(None, "Next"))
+                    .min_width(200),
+            );
         } else {
             row = row.push(
-                button::primary(&mut self.save_button, button::button_content(None, "Save"))
-                    .on_press(Message::Next),
+                button::primary(&mut self.save_button, button::button_content(None, "Next"))
+                    .on_press(Message::Next)
+                    .min_width(200),
             );
         }
 
@@ -815,14 +822,15 @@ impl DefineEmergencyAddress {
     pub fn render<'a>(&'a mut self, address: &str, warning: bool) -> Element<'a, Message> {
         let mut row = Row::new().align_items(Align::Center).spacing(20);
         if warning {
-            row = row.push(button::primary(
-                &mut self.save_button,
-                button::button_content(None, "Save"),
-            ));
+            row = row.push(
+                button::primary(&mut self.save_button, button::button_content(None, "Next"))
+                    .min_width(200),
+            );
         } else {
             row = row.push(
-                button::primary(&mut self.save_button, button::button_content(None, "Save"))
-                    .on_press(Message::Next),
+                button::primary(&mut self.save_button, button::button_content(None, "Next"))
+                    .on_press(Message::Next)
+                    .min_width(200),
             );
         }
         let mut col = Column::new()
@@ -968,8 +976,9 @@ impl DefineWatchtowers {
                         .spacing(10),
                 )
                 .push(
-                    button::primary(&mut self.save_button, button::button_content(None, "Save"))
-                        .on_press(Message::Next),
+                    button::primary(&mut self.save_button, button::button_content(None, "Next"))
+                        .on_press(Message::Next)
+                        .min_width(200),
                 )
                 .width(Length::Fill)
                 .height(Length::Fill)
@@ -1069,8 +1078,9 @@ impl DefineCosigners {
                         .spacing(10),
                 )
                 .push(
-                    button::primary(&mut self.save_button, button::button_content(None, "Save"))
-                        .on_press(Message::Next),
+                    button::primary(&mut self.save_button, button::button_content(None, "Next"))
+                        .on_press(Message::Next)
+                        .min_width(200),
                 )
                 .width(Length::Fill)
                 .height(Length::Fill)
@@ -1163,8 +1173,9 @@ impl DefineBitcoind {
                 .push(col_address)
                 .push(col_cookie)
                 .push(
-                    button::primary(&mut self.save_button, button::button_content(None, "Save"))
-                        .on_press(Message::Next),
+                    button::primary(&mut self.save_button, button::button_content(None, "Next"))
+                        .on_press(Message::Next)
+                        .min_width(200),
                 )
                 .width(Length::Fill)
                 .height(Length::Fill)
@@ -1210,10 +1221,13 @@ impl Final {
         }
 
         if generating {
-            col = col.push(button::primary(
-                &mut self.action_button,
-                button::button_content(None, "Installing ..."),
-            ))
+            col = col.push(
+                button::primary(
+                    &mut self.action_button,
+                    button::button_content(None, "Installing ..."),
+                )
+                .min_width(200),
+            )
         } else if let Some(path) = config_path {
             col = col.push(card::border_success(
                 Container::new(
@@ -1224,7 +1238,8 @@ impl Final {
                                 &mut self.action_button,
                                 button::button_content(None, "Start"),
                             )
-                            .on_press(Message::Exit(path.clone())),
+                            .on_press(Message::Exit(path.clone()))
+                            .min_width(200),
                         ))
                         .align_items(Align::Center)
                         .spacing(20),
@@ -1239,7 +1254,8 @@ impl Final {
                     &mut self.action_button,
                     button::button_content(None, "Finalize installation"),
                 )
-                .on_press(Message::Install),
+                .on_press(Message::Install)
+                .min_width(200),
             );
         }
 

--- a/src/installer/view.rs
+++ b/src/installer/view.rs
@@ -1137,7 +1137,7 @@ impl DefineBitcoind {
 pub struct Final {
     scroll: scrollable::State,
     previous_button: Button,
-    generate_button: Button,
+    action_button: Button,
 }
 
 impl Final {
@@ -1145,7 +1145,7 @@ impl Final {
         Self {
             scroll: scrollable::State::new(),
             previous_button: Button::new(),
-            generate_button: Button::new(),
+            action_button: Button::new(),
         }
     }
 
@@ -1169,19 +1169,36 @@ impl Final {
 
         if generating {
             col = col.push(button::primary(
-                &mut self.generate_button,
+                &mut self.action_button,
                 button::button_content(None, "Installing ..."),
             ))
         } else if !success {
             col = col.push(
                 button::primary(
-                    &mut self.generate_button,
+                    &mut self.action_button,
                     button::button_content(None, "Finalize installation"),
                 )
                 .on_press(Message::Install),
             );
         } else {
-            col = col.push(card::success(Container::new(text::simple("Installed !"))));
+            col = col.push(card::border_success(
+                Container::new(
+                    Column::new()
+                        .push(Container::new(text::simple("Installed !")))
+                        .push(Container::new(
+                            button::primary(
+                                &mut self.action_button,
+                                button::button_content(None, "Start"),
+                            )
+                            .on_press(Message::Exit),
+                        ))
+                        .align_items(Align::Center)
+                        .spacing(20),
+                )
+                .padding(50)
+                .width(Length::Fill)
+                .align_x(Align::Center),
+            ));
         }
 
         layout(&mut self.scroll, &mut self.previous_button, col.into())

--- a/src/installer/view.rs
+++ b/src/installer/view.rs
@@ -179,19 +179,14 @@ impl DefinePrivateNoiseKey {
             &mut self.scroll,
             &mut self.previous_button,
             Column::new()
-                .push(text::bold(text::simple("Fill private noise key:")).size(50))
+                .push(text::bold(text::simple("Fill your private noise key:")).size(50))
                 .push(
                     Column::new().spacing(10).push(
-                        form::Form::new(
-                            &mut self.key_input,
-                            "The private noise key",
-                            key,
-                            Message::PrivateNoiseKey,
-                        )
-                        .warning("Noise key must be 32 bytes long")
-                        .size(15)
-                        .padding(10)
-                        .render(),
+                        form::Form::new(&mut self.key_input, "", key, Message::PrivateNoiseKey)
+                            .warning("Noise key must be 32 bytes long")
+                            .size(15)
+                            .padding(10)
+                            .render(),
                     ),
                 )
                 .push(

--- a/src/installer/view.rs
+++ b/src/installer/view.rs
@@ -300,12 +300,12 @@ pub fn define_stakeholder_xpubs_as_manager_only<'a>(
     )
 }
 
-pub struct ManagersTreshold {
+pub struct ManagersThreshold {
     increment_button: Button,
     decrement_button: Button,
 }
 
-impl ManagersTreshold {
+impl ManagersThreshold {
     pub fn new() -> Self {
         Self {
             increment_button: Button::new(),
@@ -313,12 +313,12 @@ impl ManagersTreshold {
         }
     }
 
-    pub fn render(&mut self, managers_treshold: usize, warning: bool) -> Container<Message> {
+    pub fn render(&mut self, managers_threshold: usize, warning: bool) -> Container<Message> {
         let mut col = Column::new()
-            .push(text::bold(text::simple("Managers treshold:")))
+            .push(text::bold(text::simple("Managers threshold:")))
             .push(
                 Row::new()
-                    .push(text::simple(&format!("{}", managers_treshold)).size(50))
+                    .push(text::simple(&format!("{}", managers_threshold)).size(50))
                     .push(
                         Column::new()
                             .push(
@@ -328,7 +328,7 @@ impl ManagersTreshold {
                                 )
                                 .on_press(
                                     Message::DefineManagerXpubs(
-                                        message::DefineManagerXpubs::ManagersTreshold(
+                                        message::DefineManagerXpubs::ManagersThreshold(
                                             message::Action::Increment,
                                         ),
                                     ),
@@ -341,7 +341,7 @@ impl ManagersTreshold {
                                 )
                                 .on_press(
                                     Message::DefineManagerXpubs(
-                                        message::DefineManagerXpubs::ManagersTreshold(
+                                        message::DefineManagerXpubs::ManagersThreshold(
                                             message::Action::Decrement,
                                         ),
                                     ),
@@ -357,7 +357,7 @@ impl ManagersTreshold {
 
         if warning {
             col = col.push(card::alert_warning(Container::new(text::small(
-                "Impossible treshold",
+                "Impossible threshold",
             ))))
         }
         Container::new(col)
@@ -428,7 +428,7 @@ impl SpendingDelay {
 }
 
 pub struct DefineManagerXpubsAsManager {
-    managers_treshold: ManagersTreshold,
+    managers_threshold: ManagersThreshold,
     spending_delay: SpendingDelay,
     add_xpub_button: Button,
     add_cosigner_button: Button,
@@ -448,14 +448,14 @@ impl DefineManagerXpubsAsManager {
             save_button: Button::new(),
             add_cosigner_button: Button::new(),
             spending_delay: SpendingDelay::new(),
-            managers_treshold: ManagersTreshold::new(),
+            managers_threshold: ManagersThreshold::new(),
         }
     }
 
     pub fn render<'a>(
         &'a mut self,
-        managers_treshold: usize,
-        treshold_warning: bool,
+        managers_threshold: usize,
+        threshold_warning: bool,
         spending_delay: u32,
         spending_delay_warning: bool,
         our_xpub: &form::Value<String>,
@@ -487,8 +487,8 @@ impl DefineManagerXpubsAsManager {
                 Row::new()
                     .push(
                         Container::new(
-                            self.managers_treshold
-                                .render(managers_treshold, treshold_warning),
+                            self.managers_threshold
+                                .render(managers_threshold, threshold_warning),
                         )
                         .width(Length::FillPortion(1))
                         .align_x(Align::Center),
@@ -573,7 +573,7 @@ impl DefineManagerXpubsAsManager {
 }
 
 pub struct DefineManagerXpubsAsStakeholderOnly {
-    managers_treshold: ManagersTreshold,
+    managers_threshold: ManagersThreshold,
     spending_delay: SpendingDelay,
     add_cosigner_button: Button,
     add_xpub_button: Button,
@@ -585,7 +585,7 @@ pub struct DefineManagerXpubsAsStakeholderOnly {
 impl DefineManagerXpubsAsStakeholderOnly {
     pub fn new() -> Self {
         Self {
-            managers_treshold: ManagersTreshold::new(),
+            managers_threshold: ManagersThreshold::new(),
             spending_delay: SpendingDelay::new(),
             add_cosigner_button: Button::new(),
             scroll: scrollable::State::new(),
@@ -596,8 +596,8 @@ impl DefineManagerXpubsAsStakeholderOnly {
     }
     pub fn render<'a>(
         &'a mut self,
-        managers_treshold: usize,
-        treshold_warning: bool,
+        managers_threshold: usize,
+        threshold_warning: bool,
         spending_delay: u32,
         spending_delay_warning: bool,
         manager_xpubs: Vec<Element<'a, Message>>,
@@ -627,8 +627,8 @@ impl DefineManagerXpubsAsStakeholderOnly {
                 Row::new()
                     .push(
                         Container::new(
-                            self.managers_treshold
-                                .render(managers_treshold, treshold_warning),
+                            self.managers_threshold
+                                .render(managers_threshold, threshold_warning),
                         )
                         .width(Length::FillPortion(1))
                         .align_x(Align::Center),

--- a/src/installer/view.rs
+++ b/src/installer/view.rs
@@ -157,6 +157,58 @@ pub fn cosigner_key<'a>(
     .into()
 }
 
+pub struct DefinePrivateNoiseKey {
+    key_input: text_input::State,
+    next_button: Button,
+    previous_button: Button,
+    scroll: scrollable::State,
+}
+
+impl DefinePrivateNoiseKey {
+    pub fn new() -> Self {
+        Self {
+            key_input: text_input::State::new(),
+            next_button: Button::new(),
+            previous_button: Button::new(),
+            scroll: scrollable::State::new(),
+        }
+    }
+
+    pub fn render<'a>(&'a mut self, key: &form::Value<String>) -> Element<Message> {
+        layout(
+            &mut self.scroll,
+            &mut self.previous_button,
+            Column::new()
+                .push(text::bold(text::simple("Fill private noise key:")).size(50))
+                .push(
+                    Column::new().spacing(10).push(
+                        form::Form::new(
+                            &mut self.key_input,
+                            "The private noise key",
+                            key,
+                            Message::PrivateNoiseKey,
+                        )
+                        .warning("Noise key must be 32 bytes long")
+                        .size(15)
+                        .padding(10)
+                        .render(),
+                    ),
+                )
+                .push(
+                    button::primary(&mut self.next_button, button::button_content(None, "Next"))
+                        .on_press(Message::Next)
+                        .min_width(200),
+                )
+                .width(Length::Fill)
+                .height(Length::Fill)
+                .padding(100)
+                .spacing(50)
+                .align_items(Align::Center)
+                .into(),
+        )
+    }
+}
+
 pub struct DefineStakeholderXpubsAsStakeholder {
     our_xpub_input: text_input::State,
     previous_button: Button,

--- a/src/installer/view.rs
+++ b/src/installer/view.rs
@@ -630,6 +630,59 @@ impl DefineManagerXpubsAsStakeholderOnly {
     }
 }
 
+pub fn define_cpfp_descriptor<'a>(
+    add_xpub_button: &'a mut Button,
+    manager_xpubs: Vec<Element<'a, Message>>,
+    scroll: &'a mut scrollable::State,
+    previous_button: &'a mut Button,
+    save_button: &'a mut Button,
+) -> Element<'a, Message> {
+    let mut row = Row::new().align_items(Align::Center).spacing(20);
+    if manager_xpubs.is_empty() {
+        row = row.push(button::primary(
+            save_button,
+            button::button_content(None, "Save"),
+        ));
+    } else {
+        row = row.push(
+            button::primary(save_button, button::button_content(None, "Save"))
+                .on_press(Message::Next),
+        );
+    }
+
+    layout(
+        scroll,
+        previous_button,
+        Column::new()
+            .push(text::bold(text::simple("Define fee bumping managers")).size(50))
+            .push(
+                Column::new()
+                    .spacing(10)
+                    .push(text::bold(text::simple("Managers xpubs:")))
+                    .push(Column::with_children(manager_xpubs).spacing(10))
+                    .push(
+                        Container::new(
+                            button::white_card_button(
+                                add_xpub_button,
+                                button::button_content(Some(icon::plus_icon()), "Add manager"),
+                            )
+                            .on_press(Message::DefineCpfpDescriptor(
+                                message::DefineCpfpDescriptor::AddXpub,
+                            )),
+                        )
+                        .width(Length::Fill),
+                    ),
+            )
+            .push(row)
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .padding(100)
+            .spacing(50)
+            .align_items(Align::Center)
+            .into(),
+    )
+}
+
 fn layout<'a>(
     scroll_state: &'a mut scrollable::State,
     previous_button: &'a mut Button,

--- a/src/installer/view.rs
+++ b/src/installer/view.rs
@@ -683,6 +683,92 @@ pub fn define_cpfp_descriptor<'a>(
     )
 }
 
+pub struct DefineCoordinator {
+    host_input: text_input::State,
+    noise_key_input: text_input::State,
+    scroll: scrollable::State,
+    previous_button: Button,
+    save_button: Button,
+}
+
+impl DefineCoordinator {
+    pub fn new() -> Self {
+        Self {
+            host_input: text_input::State::new(),
+            noise_key_input: text_input::State::new(),
+            scroll: scrollable::State::new(),
+            previous_button: Button::new(),
+            save_button: Button::new(),
+        }
+    }
+    pub fn render<'a>(
+        &'a mut self,
+        host: &str,
+        noise_key: &str,
+        warning: bool,
+    ) -> Element<'a, Message> {
+        let mut row = Row::new().align_items(Align::Center).spacing(20);
+        if warning {
+            row = row.push(button::primary(
+                &mut self.save_button,
+                button::button_content(None, "Save"),
+            ));
+        } else {
+            row = row.push(
+                button::primary(&mut self.save_button, button::button_content(None, "Save"))
+                    .on_press(Message::Next),
+            );
+        }
+
+        layout(
+            &mut self.scroll,
+            &mut self.previous_button,
+            Column::new()
+                .push(text::bold(text::simple("Define coordinator")).size(50))
+                .push(
+                    Column::new()
+                        .push(text::bold(text::simple("Host:")))
+                        .push(
+                            TextInput::new(&mut self.host_input, "Host", host, |msg| {
+                                Message::DefineCoordinator(message::DefineCoordinator::HostEdited(
+                                    msg,
+                                ))
+                            })
+                            .size(15)
+                            .padding(10),
+                        )
+                        .spacing(10),
+                )
+                .push(
+                    Column::new()
+                        .push(text::bold(text::simple("Noise key:")))
+                        .push(
+                            TextInput::new(
+                                &mut self.noise_key_input,
+                                "Noise key",
+                                noise_key,
+                                |msg| {
+                                    Message::DefineCoordinator(
+                                        message::DefineCoordinator::NoiseKeyEdited(msg),
+                                    )
+                                },
+                            )
+                            .size(15)
+                            .padding(10),
+                        )
+                        .spacing(10),
+                )
+                .push(row)
+                .width(Length::Fill)
+                .height(Length::Fill)
+                .padding(100)
+                .spacing(50)
+                .align_items(Align::Center)
+                .into(),
+        )
+    }
+}
+
 fn layout<'a>(
     scroll_state: &'a mut scrollable::State,
     previous_button: &'a mut Button,

--- a/src/installer/view.rs
+++ b/src/installer/view.rs
@@ -868,7 +868,11 @@ impl DefineEmergencyAddress {
             save_button: Button::new(),
         }
     }
-    pub fn render<'a>(&'a mut self, address: &form::Value<String>) -> Element<'a, Message> {
+    pub fn render<'a>(
+        &'a mut self,
+        address: &form::Value<String>,
+        warning: Option<&String>,
+    ) -> Element<'a, Message> {
         let mut row = Row::new().align_items(Align::Center).spacing(20);
         if !address.valid {
             row = row.push(
@@ -882,7 +886,7 @@ impl DefineEmergencyAddress {
                     .min_width(200),
             );
         }
-        let col = Column::new()
+        let mut col = Column::new()
             .push(text::bold(text::simple("Address:")))
             .push(
                 form::Form::new(
@@ -897,6 +901,10 @@ impl DefineEmergencyAddress {
                 .render(),
             )
             .spacing(10);
+
+        if let Some(error) = warning {
+            col = col.push(card::alert_warning(Container::new(text::simple(&error))));
+        }
 
         layout(
             &mut self.scroll,

--- a/src/installer/view.rs
+++ b/src/installer/view.rs
@@ -275,49 +275,54 @@ impl ManagersTreshold {
         }
     }
 
-    pub fn render(&mut self, managers_treshold: usize) -> Container<Message> {
-        Container::new(
-            Column::new()
-                .push(text::bold(text::simple("Managers treshold:")))
-                .push(
-                    Row::new()
-                        .push(text::simple(&format!("{}", managers_treshold)).size(50))
-                        .push(
-                            Column::new()
-                                .push(
-                                    button::transparent(
-                                        &mut self.increment_button,
-                                        Container::new(text::simple("+")),
-                                    )
-                                    .on_press(
-                                        Message::DefineManagerXpubs(
-                                            message::DefineManagerXpubs::ManagersTreshold(
-                                                message::Action::Increment,
-                                            ),
+    pub fn render(&mut self, managers_treshold: usize, warning: bool) -> Container<Message> {
+        let mut col = Column::new()
+            .push(text::bold(text::simple("Managers treshold:")))
+            .push(
+                Row::new()
+                    .push(text::simple(&format!("{}", managers_treshold)).size(50))
+                    .push(
+                        Column::new()
+                            .push(
+                                button::transparent(
+                                    &mut self.increment_button,
+                                    Container::new(text::simple("+")),
+                                )
+                                .on_press(
+                                    Message::DefineManagerXpubs(
+                                        message::DefineManagerXpubs::ManagersTreshold(
+                                            message::Action::Increment,
                                         ),
                                     ),
+                                ),
+                            )
+                            .push(
+                                button::transparent(
+                                    &mut self.decrement_button,
+                                    Container::new(text::simple("-")),
                                 )
-                                .push(
-                                    button::transparent(
-                                        &mut self.decrement_button,
-                                        Container::new(text::simple("-")),
-                                    )
-                                    .on_press(
-                                        Message::DefineManagerXpubs(
-                                            message::DefineManagerXpubs::ManagersTreshold(
-                                                message::Action::Decrement,
-                                            ),
+                                .on_press(
+                                    Message::DefineManagerXpubs(
+                                        message::DefineManagerXpubs::ManagersTreshold(
+                                            message::Action::Decrement,
                                         ),
                                     ),
-                                )
-                                .align_items(Align::Center),
-                        )
-                        .align_items(Align::Center)
-                        .spacing(20),
-                )
-                .align_items(Align::Center)
-                .spacing(10),
-        )
+                                ),
+                            )
+                            .align_items(Align::Center),
+                    )
+                    .align_items(Align::Center)
+                    .spacing(20),
+            )
+            .align_items(Align::Center)
+            .spacing(10);
+
+        if warning {
+            col = col.push(card::alert_warning(Container::new(text::small(
+                "Impossible treshold",
+            ))))
+        }
+        Container::new(col)
     }
 }
 
@@ -334,49 +339,53 @@ impl SpendingDelay {
         }
     }
 
-    pub fn render(&mut self, spending_delay: u32) -> Container<Message> {
-        Container::new(
-            Column::new()
-                .push(text::bold(text::simple("Spending delay in blocks:")))
-                .push(
-                    Row::new()
-                        .push(text::simple(&format!("{}", spending_delay)).size(50))
-                        .push(
-                            Column::new()
-                                .push(
-                                    button::transparent(
-                                        &mut self.increment_button,
-                                        Container::new(text::simple("+")),
-                                    )
-                                    .on_press(
-                                        Message::DefineManagerXpubs(
-                                            message::DefineManagerXpubs::SpendingDelay(
-                                                message::Action::Increment,
-                                            ),
+    pub fn render(&mut self, spending_delay: u32, warning: bool) -> Container<Message> {
+        let mut col = Column::new()
+            .push(text::bold(text::simple("Spending delay in blocks:")))
+            .push(
+                Row::new()
+                    .push(text::simple(&format!("{}", spending_delay)).size(50))
+                    .push(
+                        Column::new()
+                            .push(
+                                button::transparent(
+                                    &mut self.increment_button,
+                                    Container::new(text::simple("+")),
+                                )
+                                .on_press(
+                                    Message::DefineManagerXpubs(
+                                        message::DefineManagerXpubs::SpendingDelay(
+                                            message::Action::Increment,
                                         ),
                                     ),
+                                ),
+                            )
+                            .push(
+                                button::transparent(
+                                    &mut self.decrement_button,
+                                    Container::new(text::simple("-")),
                                 )
-                                .push(
-                                    button::transparent(
-                                        &mut self.decrement_button,
-                                        Container::new(text::simple("-")),
-                                    )
-                                    .on_press(
-                                        Message::DefineManagerXpubs(
-                                            message::DefineManagerXpubs::SpendingDelay(
-                                                message::Action::Decrement,
-                                            ),
+                                .on_press(
+                                    Message::DefineManagerXpubs(
+                                        message::DefineManagerXpubs::SpendingDelay(
+                                            message::Action::Decrement,
                                         ),
                                     ),
-                                )
-                                .align_items(Align::Center),
-                        )
-                        .align_items(Align::Center)
-                        .spacing(20),
-                )
-                .align_items(Align::Center)
-                .spacing(10),
-        )
+                                ),
+                            )
+                            .align_items(Align::Center),
+                    )
+                    .align_items(Align::Center)
+                    .spacing(20),
+            )
+            .align_items(Align::Center)
+            .spacing(10);
+        if warning {
+            col = col.push(card::alert_warning(Container::new(text::small(
+                "Spending delay cannot be equal to zero",
+            ))))
+        }
+        Container::new(col)
     }
 }
 
@@ -408,7 +417,9 @@ impl DefineManagerXpubsAsManager {
     pub fn render<'a>(
         &'a mut self,
         managers_treshold: usize,
+        treshold_warning: bool,
         spending_delay: u32,
+        spending_delay_warning: bool,
         our_xpub: &str,
         our_xpub_warning: bool,
         other_xpubs: Vec<Element<'a, Message>>,
@@ -443,14 +454,20 @@ impl DefineManagerXpubsAsManager {
                 .push(
                     Row::new()
                         .push(
-                            Container::new(self.managers_treshold.render(managers_treshold))
-                                .width(Length::FillPortion(1))
-                                .align_x(Align::Center),
+                            Container::new(
+                                self.managers_treshold
+                                    .render(managers_treshold, treshold_warning),
+                            )
+                            .width(Length::FillPortion(1))
+                            .align_x(Align::Center),
                         )
                         .push(
-                            Container::new(self.spending_delay.render(spending_delay))
-                                .width(Length::FillPortion(1))
-                                .align_x(Align::Center),
+                            Container::new(
+                                self.spending_delay
+                                    .render(spending_delay, spending_delay_warning),
+                            )
+                            .width(Length::FillPortion(1))
+                            .align_x(Align::Center),
                         )
                         .width(Length::Fill),
                 )
@@ -545,7 +562,9 @@ impl DefineManagerXpubsAsStakeholderOnly {
     pub fn render<'a>(
         &'a mut self,
         managers_treshold: usize,
+        treshold_warning: bool,
         spending_delay: u32,
+        spending_delay_warning: bool,
         manager_xpubs: Vec<Element<'a, Message>>,
         cosigners: Vec<Element<'a, Message>>,
     ) -> Element<'a, Message> {
@@ -570,14 +589,20 @@ impl DefineManagerXpubsAsStakeholderOnly {
                 .push(
                     Row::new()
                         .push(
-                            Container::new(self.managers_treshold.render(managers_treshold))
-                                .width(Length::FillPortion(1))
-                                .align_x(Align::Center),
+                            Container::new(
+                                self.managers_treshold
+                                    .render(managers_treshold, treshold_warning),
+                            )
+                            .width(Length::FillPortion(1))
+                            .align_x(Align::Center),
                         )
                         .push(
-                            Container::new(self.spending_delay.render(spending_delay))
-                                .width(Length::FillPortion(1))
-                                .align_x(Align::Center),
+                            Container::new(
+                                self.spending_delay
+                                    .render(spending_delay, spending_delay_warning),
+                            )
+                            .width(Length::FillPortion(1))
+                            .align_x(Align::Center),
                         )
                         .width(Length::Fill),
                 )

--- a/src/installer/view.rs
+++ b/src/installer/view.rs
@@ -788,6 +788,7 @@ impl DefineCoordinator {
                 )
                 .push(
                     button::primary(&mut self.save_button, button::button_content(None, "Next"))
+                        .on_press(Message::Next)
                         .min_width(200),
                 )
                 .width(Length::Fill)

--- a/src/installer/view.rs
+++ b/src/installer/view.rs
@@ -116,6 +116,24 @@ pub fn participant_xpub<'a>(
     .into()
 }
 
+pub fn required_xpub<'a>(
+    xpub: &form::Value<String>,
+    xpub_input: &'a mut text_input::State,
+) -> Element<'a, String> {
+    Container::new(
+        Column::new()
+            .push(
+                form::Form::new(xpub_input, "Xpub", xpub, |msg| msg)
+                    .warning("Please enter a valid xpub")
+                    .size(15)
+                    .padding(10)
+                    .render(),
+            )
+            .spacing(10),
+    )
+    .into()
+}
+
 pub fn cosigner_key<'a>(
     key: &form::Value<String>,
     key_input: &'a mut text_input::State,
@@ -663,62 +681,64 @@ impl DefineManagerXpubsAsStakeholderOnly {
     }
 }
 
-pub fn define_cpfp_descriptor<'a>(
-    add_xpub_button: &'a mut Button,
-    manager_xpubs: Vec<Element<'a, Message>>,
-    scroll: &'a mut scrollable::State,
-    previous_button: &'a mut Button,
-    save_button: &'a mut Button,
-    warning: Option<&String>,
-) -> Element<'a, Message> {
-    let mut row = Row::new().align_items(Align::Center).spacing(20);
-    if manager_xpubs.is_empty() {
-        row = row.push(
-            button::primary(save_button, button::button_content(None, "Next")).min_width(200),
-        );
-    } else {
-        row = row.push(
-            button::primary(save_button, button::button_content(None, "Next"))
-                .on_press(Message::Next)
-                .min_width(200),
-        );
+pub struct DefineCpfpDescriptorView {
+    scroll: scrollable::State,
+    previous_button: Button,
+    save_button: Button,
+}
+
+impl DefineCpfpDescriptorView {
+    pub fn new() -> Self {
+        Self {
+            scroll: scrollable::State::new(),
+            previous_button: Button::new(),
+            save_button: Button::new(),
+        }
     }
 
-    let mut content = Column::new()
-        .spacing(10)
-        .push(text::bold(text::simple("Managers CPFP xpubs:")))
-        .push(Column::with_children(manager_xpubs).spacing(10))
-        .push(
-            Container::new(
-                button::white_card_button(
-                    add_xpub_button,
-                    button::button_content(Some(icon::plus_icon()), "Add manager"),
-                )
-                .on_press(Message::DefineCpfpDescriptor(
-                    message::DefineCpfpDescriptor::AddXpub,
-                )),
-            )
-            .width(Length::Fill),
-        );
+    pub fn render<'a>(
+        &'a mut self,
+        manager_xpubs: Vec<Element<'a, Message>>,
+        warning: Option<&String>,
+    ) -> Element<'a, Message> {
+        let mut row = Row::new().align_items(Align::Center).spacing(20);
+        if manager_xpubs.is_empty() {
+            row = row.push(
+                button::primary(&mut self.save_button, button::button_content(None, "Next"))
+                    .min_width(200),
+            );
+        } else {
+            row = row.push(
+                button::primary(&mut self.save_button, button::button_content(None, "Next"))
+                    .on_press(Message::Next)
+                    .min_width(200),
+            );
+        }
 
-    if let Some(error) = warning {
-        content = content.push(card::alert_warning(Container::new(text::simple(&error))));
+        let mut content = Column::new()
+            .spacing(10)
+            .push(text::bold(text::simple("Managers CPFP xpubs:")))
+            .push(Column::with_children(manager_xpubs).spacing(10));
+
+        if let Some(error) = warning {
+            content = content.push(card::alert_warning(Container::new(text::simple(&error))));
+        }
+
+        layout(
+            &mut self.scroll,
+            &mut self.previous_button,
+            Column::new()
+                .push(text::bold(text::simple("Fill in the managers CPFP xpubs")).size(50))
+                .push(content)
+                .push(row)
+                .width(Length::Fill)
+                .height(Length::Fill)
+                .padding(100)
+                .spacing(50)
+                .align_items(Align::Center)
+                .into(),
+        )
     }
-
-    layout(
-        scroll,
-        previous_button,
-        Column::new()
-            .push(text::bold(text::simple("Fill in the managers CPFP xpubs")).size(50))
-            .push(content)
-            .push(row)
-            .width(Length::Fill)
-            .height(Length::Fill)
-            .padding(100)
-            .spacing(50)
-            .align_items(Align::Center)
-            .into(),
-    )
 }
 
 pub struct DefineCoordinator {

--- a/src/installer/view.rs
+++ b/src/installer/view.rs
@@ -120,22 +120,17 @@ pub fn participant_xpub<'a>(
 pub fn cosigner_key<'a>(
     key: &form::Value<String>,
     key_input: &'a mut text_input::State,
-    delete_button: &'a mut Button,
-) -> Element<'a, message::CosignerKey> {
+) -> Element<'a, String> {
     Container::new(
         Column::new()
             .push(
                 Row::new()
                     .push(
-                        form::Form::new(key_input, "Key", key, message::CosignerKey::KeyEdited)
+                        form::Form::new(key_input, "Key", key, |msg| msg)
                             .warning("Please enter a valid key")
                             .size(15)
                             .padding(10)
                             .render(),
-                    )
-                    .push(
-                        button::transparent(delete_button, Container::new(icon::trash_icon()))
-                            .on_press(message::CosignerKey::Delete),
                     )
                     .spacing(5)
                     .align_items(Align::Center),
@@ -431,7 +426,6 @@ pub struct DefineManagerXpubsAsManager {
     managers_threshold: ManagersThreshold,
     spending_delay: SpendingDelay,
     add_xpub_button: Button,
-    add_cosigner_button: Button,
     our_xpub_input: text_input::State,
     scroll: scrollable::State,
     previous_button: Button,
@@ -446,7 +440,6 @@ impl DefineManagerXpubsAsManager {
             scroll: scrollable::State::new(),
             previous_button: Button::new(),
             save_button: Button::new(),
-            add_cosigner_button: Button::new(),
             spending_delay: SpendingDelay::new(),
             managers_threshold: ManagersThreshold::new(),
         }
@@ -524,20 +517,8 @@ impl DefineManagerXpubsAsManager {
             )
             .push(
                 Column::new()
-                    .push(text::bold(text::simple("Cosigners keys:")))
+                    .push(text::bold(text::simple("Cosigning servers keys:")))
                     .push(Column::with_children(cosigners).spacing(10))
-                    .push(
-                        Container::new(
-                            button::white_card_button(
-                                &mut self.add_cosigner_button,
-                                button::button_content(Some(icon::plus_icon()), "Add cosigner key"),
-                            )
-                            .on_press(Message::DefineManagerXpubs(
-                                message::DefineManagerXpubs::AddCosigner,
-                            )),
-                        )
-                        .width(Length::Fill),
-                    )
                     .spacing(10),
             )
             .push(
@@ -575,7 +556,6 @@ impl DefineManagerXpubsAsManager {
 pub struct DefineManagerXpubsAsStakeholderOnly {
     managers_threshold: ManagersThreshold,
     spending_delay: SpendingDelay,
-    add_cosigner_button: Button,
     add_xpub_button: Button,
     scroll: scrollable::State,
     previous_button: Button,
@@ -587,7 +567,6 @@ impl DefineManagerXpubsAsStakeholderOnly {
         Self {
             managers_threshold: ManagersThreshold::new(),
             spending_delay: SpendingDelay::new(),
-            add_cosigner_button: Button::new(),
             scroll: scrollable::State::new(),
             previous_button: Button::new(),
             save_button: Button::new(),
@@ -622,7 +601,7 @@ impl DefineManagerXpubsAsStakeholderOnly {
         }
 
         let mut content = Column::new()
-            .push(text::bold(text::simple("Define managers")).size(50))
+            .push(text::bold(text::simple("Fill fund management information:")).size(50))
             .push(
                 Row::new()
                     .push(
@@ -664,20 +643,8 @@ impl DefineManagerXpubsAsStakeholderOnly {
             .push(
                 Column::new()
                     .spacing(10)
-                    .push(text::bold(text::simple("Cosigners keys:")))
-                    .push(Column::with_children(cosigners).spacing(10))
-                    .push(
-                        Container::new(
-                            button::white_card_button(
-                                &mut self.add_cosigner_button,
-                                button::button_content(Some(icon::plus_icon()), "Add cosigner"),
-                            )
-                            .on_press(Message::DefineManagerXpubs(
-                                message::DefineManagerXpubs::AddCosigner,
-                            )),
-                        )
-                        .width(Length::Fill),
-                    ),
+                    .push(text::bold(text::simple("Cosigning servers keys:")))
+                    .push(Column::with_children(cosigners).spacing(10)),
             )
             .width(Length::Fill)
             .height(Length::Fill)
@@ -720,7 +687,7 @@ pub fn define_cpfp_descriptor<'a>(
 
     let mut content = Column::new()
         .spacing(10)
-        .push(text::bold(text::simple("Managers xpubs:")))
+        .push(text::bold(text::simple("Managers CPFP xpubs:")))
         .push(Column::with_children(manager_xpubs).spacing(10))
         .push(
             Container::new(
@@ -743,7 +710,7 @@ pub fn define_cpfp_descriptor<'a>(
         scroll,
         previous_button,
         Column::new()
-            .push(text::bold(text::simple("Define fee bumping managers")).size(50))
+            .push(text::bold(text::simple("Fill in the managers CPFP xpubs")).size(50))
             .push(content)
             .push(row)
             .width(Length::Fill)
@@ -797,7 +764,7 @@ impl DefineCoordinator {
             &mut self.scroll,
             &mut self.previous_button,
             Column::new()
-                .push(text::bold(text::simple("Define coordinator")).size(50))
+                .push(text::bold(text::simple("Fill in coordinator information")).size(50))
                 .push(
                     Column::new()
                         .push(text::bold(text::simple("Host:")))
@@ -892,7 +859,7 @@ impl DefineEmergencyAddress {
             &mut self.scroll,
             &mut self.previous_button,
             Column::new()
-                .push(text::bold(text::simple("Define emergency address")).size(50))
+                .push(text::bold(text::simple("Fill in emergency information")).size(50))
                 .push(col)
                 .push(row)
                 .width(Length::Fill)
@@ -992,7 +959,7 @@ impl DefineWatchtowers {
             &mut self.scroll,
             &mut self.previous_button,
             Column::new()
-                .push(text::bold(text::simple("Define your watchtowers")).size(50))
+                .push(text::bold(text::simple("Fill in watchtowers information")).size(50))
                 .push(
                     Column::new()
                         .push(
@@ -1100,11 +1067,11 @@ impl DefineCosigners {
             &mut self.scroll,
             &mut self.previous_button,
             Column::new()
-                .push(text::bold(text::simple("Define the cosigners")).size(50))
+                .push(text::bold(text::simple("Fill in cosigning servers information")).size(50))
                 .push(
                     Column::new()
                         .push(
-                            Container::new(text::bold(text::simple("The cosigners:")))
+                            Container::new(text::bold(text::simple("The cosigning servers:")))
                                 .width(Length::Fill),
                         )
                         .push(Column::with_children(cosigners).spacing(10))
@@ -1189,7 +1156,9 @@ impl DefineBitcoind {
             &mut self.scroll,
             &mut self.previous_button,
             Column::new()
-                .push(text::bold(text::simple("Define bitcoind")).size(50))
+                .push(
+                    text::bold(text::simple("Set up connection to the Bitcoin full node")).size(50),
+                )
                 .push(Container::new(
                     pick_list::PickList::new(
                         &mut self.network_input,
@@ -1238,7 +1207,6 @@ impl Final {
         warning: Option<&String>,
     ) -> Element<Message> {
         let mut col = Column::new()
-            .push(text::bold(text::simple("You reached the end")).size(50))
             .width(Length::Fill)
             .height(Length::Fill)
             .padding(100)

--- a/src/installer/view.rs
+++ b/src/installer/view.rs
@@ -8,7 +8,9 @@ use crate::{
     revault::Role,
     ui::{
         color,
-        component::{button, image::revault_colored_logo, scroll, text, ContainerBackgroundStyle},
+        component::{
+            button, card, image::revault_colored_logo, scroll, text, ContainerBackgroundStyle,
+        },
         icon,
     },
 };
@@ -1129,6 +1131,60 @@ impl DefineBitcoind {
                 .align_items(Align::Center)
                 .into(),
         )
+    }
+}
+
+pub struct Final {
+    scroll: scrollable::State,
+    previous_button: Button,
+    generate_button: Button,
+}
+
+impl Final {
+    pub fn new() -> Self {
+        Self {
+            scroll: scrollable::State::new(),
+            previous_button: Button::new(),
+            generate_button: Button::new(),
+        }
+    }
+
+    pub fn render(
+        &mut self,
+        generating: bool,
+        success: bool,
+        warning: Option<&String>,
+    ) -> Element<Message> {
+        let mut col = Column::new()
+            .push(text::bold(text::simple("You reached the end")).size(50))
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .padding(100)
+            .spacing(50)
+            .align_items(Align::Center);
+
+        if let Some(error) = warning {
+            col = col.push(card::alert_warning(Container::new(text::simple(error))));
+        }
+
+        if generating {
+            col = col.push(button::primary(
+                &mut self.generate_button,
+                button::button_content(None, "Installing ..."),
+            ))
+        } else if !success {
+            col = col.push(
+                button::primary(
+                    &mut self.generate_button,
+                    button::button_content(None, "Finalize installation"),
+                )
+                .on_press(Message::Install),
+            );
+        } else {
+            col = col.push(card::success(Container::new(text::simple("Installed !"))));
+        }
+
+        layout(&mut self.scroll, &mut self.previous_button, col.into())
     }
 }
 

--- a/src/installer/view.rs
+++ b/src/installer/view.rs
@@ -1131,42 +1131,38 @@ impl DefineBitcoind {
     pub fn render<'a>(
         &'a mut self,
         network: &bitcoin::Network,
-        address: &str,
-        cookie_path: &str,
-        warning_address: bool,
-        warning_cookie_path: bool,
+        address: &form::Value<String>,
+        cookie_path: &form::Value<String>,
     ) -> Element<'a, Message> {
-        let mut col_address = Column::new()
+        let col_address = Column::new()
             .push(text::bold(text::simple("Address:")))
             .push(
-                TextInput::new(&mut self.address_input, "Address", address, |msg| {
+                form::Form::new(&mut self.address_input, "Address", address, |msg| {
                     Message::DefineBitcoind(message::DefineBitcoind::AddressEdited(msg))
                 })
+                .warning("Please enter correct address")
                 .size(15)
-                .padding(10),
+                .padding(10)
+                .render(),
             )
             .spacing(10);
-        if warning_address {
-            col_address = col_address
-                .push(text::simple("Please enter correct address").color(color::WARNING));
-        }
-        let mut col_cookie = Column::new()
+
+        let col_cookie = Column::new()
             .push(text::bold(text::simple("Cookie path:")))
             .push(
-                TextInput::new(
+                form::Form::new(
                     &mut self.cookie_path_input,
                     "Cookie path",
                     cookie_path,
                     |msg| Message::DefineBitcoind(message::DefineBitcoind::CookiePathEdited(msg)),
                 )
+                .warning("Please enter correct path")
                 .size(15)
-                .padding(10),
+                .padding(10)
+                .render(),
             )
             .spacing(10);
-        if warning_cookie_path {
-            col_cookie =
-                col_cookie.push(text::simple("Please enter correct path").color(color::WARNING));
-        }
+
         layout(
             &mut self.scroll,
             &mut self.previous_button,

--- a/src/installer/view.rs
+++ b/src/installer/view.rs
@@ -1194,7 +1194,7 @@ impl Final {
     pub fn render(
         &mut self,
         generating: bool,
-        success: bool,
+        config_path: Option<&std::path::PathBuf>,
         warning: Option<&String>,
     ) -> Element<Message> {
         let mut col = Column::new()
@@ -1214,15 +1214,7 @@ impl Final {
                 &mut self.action_button,
                 button::button_content(None, "Installing ..."),
             ))
-        } else if !success {
-            col = col.push(
-                button::primary(
-                    &mut self.action_button,
-                    button::button_content(None, "Finalize installation"),
-                )
-                .on_press(Message::Install),
-            );
-        } else {
+        } else if let Some(path) = config_path {
             col = col.push(card::border_success(
                 Container::new(
                     Column::new()
@@ -1232,7 +1224,7 @@ impl Final {
                                 &mut self.action_button,
                                 button::button_content(None, "Start"),
                             )
-                            .on_press(Message::Exit),
+                            .on_press(Message::Exit(path.clone())),
                         ))
                         .align_items(Align::Center)
                         .spacing(20),
@@ -1241,6 +1233,14 @@ impl Final {
                 .width(Length::Fill)
                 .align_x(Align::Center),
             ));
+        } else {
+            col = col.push(
+                button::primary(
+                    &mut self.action_button,
+                    button::button_content(None, "Finalize installation"),
+                )
+                .on_press(Message::Install),
+            );
         }
 
         layout(&mut self.scroll, &mut self.previous_button, col.into())

--- a/src/installer/view.rs
+++ b/src/installer/view.rs
@@ -1055,6 +1055,83 @@ impl DefineCosigners {
     }
 }
 
+pub struct DefineBitcoind {
+    address_input: text_input::State,
+    cookie_path_input: text_input::State,
+    scroll: scrollable::State,
+    previous_button: Button,
+    save_button: Button,
+}
+
+impl DefineBitcoind {
+    pub fn new() -> Self {
+        Self {
+            address_input: text_input::State::new(),
+            cookie_path_input: text_input::State::new(),
+            scroll: scrollable::State::new(),
+            previous_button: Button::new(),
+            save_button: Button::new(),
+        }
+    }
+    pub fn render<'a>(
+        &'a mut self,
+        address: &str,
+        cookie_path: &str,
+        warning_address: bool,
+        warning_cookie_path: bool,
+    ) -> Element<'a, Message> {
+        let mut col_address = Column::new()
+            .push(text::bold(text::simple("Address:")))
+            .push(
+                TextInput::new(&mut self.address_input, "Address", address, |msg| {
+                    Message::DefineBitcoind(message::DefineBitcoind::AddressEdited(msg))
+                })
+                .size(15)
+                .padding(10),
+            )
+            .spacing(10);
+        if warning_address {
+            col_address = col_address
+                .push(text::simple("Please enter correct address").color(color::WARNING));
+        }
+        let mut col_cookie = Column::new()
+            .push(text::bold(text::simple("Cookie path:")))
+            .push(
+                TextInput::new(
+                    &mut self.cookie_path_input,
+                    "Cookie path",
+                    cookie_path,
+                    |msg| Message::DefineBitcoind(message::DefineBitcoind::CookiePathEdited(msg)),
+                )
+                .size(15)
+                .padding(10),
+            )
+            .spacing(10);
+        if warning_cookie_path {
+            col_cookie =
+                col_cookie.push(text::simple("Please enter correct path").color(color::WARNING));
+        }
+        layout(
+            &mut self.scroll,
+            &mut self.previous_button,
+            Column::new()
+                .push(text::bold(text::simple("Define bitcoind")).size(50))
+                .push(col_address)
+                .push(col_cookie)
+                .push(
+                    button::primary(&mut self.save_button, button::button_content(None, "Save"))
+                        .on_press(Message::Next),
+                )
+                .width(Length::Fill)
+                .height(Length::Fill)
+                .padding(100)
+                .spacing(50)
+                .align_items(Align::Center)
+                .into(),
+        )
+    }
+}
+
 fn layout<'a>(
     scroll_state: &'a mut scrollable::State,
     previous_button: &'a mut Button,

--- a/src/installer/view.rs
+++ b/src/installer/view.rs
@@ -9,7 +9,7 @@ use crate::{
     ui::{
         color,
         component::{
-            button, card, image::revault_colored_logo, scroll, text, ContainerBackgroundStyle,
+            button, card, form, image::revault_colored_logo, scroll, text, ContainerBackgroundStyle,
         },
         icon,
     },
@@ -85,62 +85,64 @@ pub fn define_role<'a>(
 }
 
 pub fn participant_xpub<'a>(
-    xpub: &str,
+    xpub: &form::Value<String>,
     xpub_input: &'a mut text_input::State,
     delete_button: &'a mut Button,
-    warning: bool,
 ) -> Element<'a, message::ParticipantXpub> {
-    let mut col = Column::new().push(
-        Row::new()
+    Container::new(
+        Column::new()
             .push(
-                TextInput::new(
-                    xpub_input,
-                    "Xpub",
-                    xpub,
-                    message::ParticipantXpub::XpubEdited,
-                )
-                .size(15)
-                .padding(10),
+                Row::new()
+                    .push(
+                        form::Form::new(
+                            xpub_input,
+                            "Xpub",
+                            xpub,
+                            message::ParticipantXpub::XpubEdited,
+                        )
+                        .warning("Please enter a valid xpub")
+                        .size(15)
+                        .padding(10)
+                        .render(),
+                    )
+                    .push(
+                        button::transparent(delete_button, Container::new(icon::trash_icon()))
+                            .on_press(message::ParticipantXpub::Delete),
+                    )
+                    .spacing(5)
+                    .align_items(Align::Center),
             )
-            .push(
-                button::transparent(delete_button, Container::new(icon::trash_icon()))
-                    .on_press(message::ParticipantXpub::Delete),
-            )
-            .spacing(5)
-            .align_items(Align::Center),
-    );
-
-    if warning {
-        col = col.push(text::simple("Please enter a valid xpub").color(color::WARNING))
-    }
-    Container::new(col.spacing(10)).into()
+            .spacing(10),
+    )
+    .into()
 }
 
 pub fn cosigner_key<'a>(
-    key: &str,
+    key: &form::Value<String>,
     key_input: &'a mut text_input::State,
     delete_button: &'a mut Button,
-    warning: bool,
 ) -> Element<'a, message::CosignerKey> {
-    let mut col = Column::new().push(
-        Row::new()
+    Container::new(
+        Column::new()
             .push(
-                TextInput::new(key_input, "Key", key, message::CosignerKey::KeyEdited)
-                    .size(15)
-                    .padding(10),
+                Row::new()
+                    .push(
+                        form::Form::new(key_input, "Key", key, message::CosignerKey::KeyEdited)
+                            .warning("Please enter a valid key")
+                            .size(15)
+                            .padding(10)
+                            .render(),
+                    )
+                    .push(
+                        button::transparent(delete_button, Container::new(icon::trash_icon()))
+                            .on_press(message::CosignerKey::Delete),
+                    )
+                    .spacing(5)
+                    .align_items(Align::Center),
             )
-            .push(
-                button::transparent(delete_button, Container::new(icon::trash_icon()))
-                    .on_press(message::CosignerKey::Delete),
-            )
-            .spacing(5)
-            .align_items(Align::Center),
-    );
-
-    if warning {
-        col = col.push(text::simple("Please enter a valid key").color(color::WARNING))
-    }
-    Container::new(col.spacing(10)).into()
+            .spacing(10),
+    )
+    .into()
 }
 
 pub fn define_stakeholder_xpubs_as_stakeholder<'a>(

--- a/src/installer/view.rs
+++ b/src/installer/view.rs
@@ -260,164 +260,374 @@ pub fn define_stakeholder_xpubs_as_manager_only<'a>(
     )
 }
 
-pub fn define_manager_xpubs_as_manager<'a>(
-    our_xpub: &str,
-    our_xpub_input: &'a mut text_input::State,
-    our_xpub_warning: bool,
-    add_xpub_button: &'a mut Button,
-    other_xpubs: Vec<Element<'a, Message>>,
-    add_cosigner_button: &'a mut Button,
-    cosigners: Vec<Element<'a, Message>>,
-    scroll: &'a mut scrollable::State,
-    previous_button: &'a mut Button,
-    save_button: &'a mut Button,
-) -> Element<'a, Message> {
-    let mut col = Column::new()
-        .push(text::bold(text::simple("Your manager xpub:")))
-        .push(
-            TextInput::new(our_xpub_input, "Your manager xpub", our_xpub, |msg| {
-                Message::DefineManagerXpubs(message::DefineManagerXpubs::OurXpubEdited(msg))
-            })
-            .size(15)
-            .padding(10),
-        )
-        .spacing(10);
-
-    if our_xpub_warning {
-        col = col.push(text::simple("Please enter a valid xpub").color(color::WARNING));
-    }
-
-    layout(
-        scroll,
-        previous_button,
-        Column::new()
-            .push(text::bold(text::simple("Define managers")).size(50))
-            .push(col)
-            .push(
-                Column::new()
-                    .push(text::bold(text::simple("Other Managers xpubs:")))
-                    .push(Column::with_children(other_xpubs).spacing(10))
-                    .push(
-                        Container::new(
-                            button::white_card_button(
-                                add_xpub_button,
-                                button::button_content(Some(icon::plus_icon()), "Add manager"),
-                            )
-                            .on_press(Message::DefineManagerXpubs(
-                                message::DefineManagerXpubs::AddXpub,
-                            )),
-                        )
-                        .width(Length::Fill),
-                    )
-                    .spacing(10),
-            )
-            .push(
-                Column::new()
-                    .push(text::bold(text::simple("Cosigners keys:")))
-                    .push(Column::with_children(cosigners).spacing(10))
-                    .push(
-                        Container::new(
-                            button::white_card_button(
-                                add_cosigner_button,
-                                button::button_content(Some(icon::plus_icon()), "Add cosigner key"),
-                            )
-                            .on_press(Message::DefineManagerXpubs(
-                                message::DefineManagerXpubs::AddCosigner,
-                            )),
-                        )
-                        .width(Length::Fill),
-                    )
-                    .spacing(10),
-            )
-            .push(
-                Row::new()
-                    .push(
-                        button::primary(save_button, button::button_content(None, "Save"))
-                            .on_press(Message::Next),
-                    )
-                    .align_items(Align::Center)
-                    .spacing(20),
-            )
-            .width(Length::Fill)
-            .height(Length::Fill)
-            .padding(100)
-            .spacing(50)
-            .align_items(Align::Center)
-            .into(),
-    )
+pub struct ManagersTreshold {
+    increment_button: Button,
+    decrement_button: Button,
 }
 
-pub fn define_manager_xpubs_as_stakeholder_only<'a>(
-    add_xpub_button: &'a mut Button,
-    manager_xpubs: Vec<Element<'a, Message>>,
-    add_cosigner_button: &'a mut Button,
-    cosigners: Vec<Element<'a, Message>>,
-    scroll: &'a mut scrollable::State,
-    previous_button: &'a mut Button,
-    save_button: &'a mut Button,
-) -> Element<'a, Message> {
-    let mut row = Row::new().align_items(Align::Center).spacing(20);
-    if manager_xpubs.is_empty() {
-        row = row.push(button::primary(
-            save_button,
-            button::button_content(None, "Save"),
-        ));
-    } else {
-        row = row.push(
-            button::primary(save_button, button::button_content(None, "Save"))
-                .on_press(Message::Next),
-        );
+impl ManagersTreshold {
+    pub fn new() -> Self {
+        Self {
+            increment_button: Button::new(),
+            decrement_button: Button::new(),
+        }
     }
 
-    layout(
-        scroll,
-        previous_button,
-        Column::new()
-            .push(text::bold(text::simple("Define managers")).size(50))
+    pub fn render(&mut self, managers_treshold: u32) -> Container<Message> {
+        Container::new(
+            Column::new()
+                .push(text::bold(text::simple("Managers treshold:")))
+                .push(
+                    Row::new()
+                        .push(text::simple(&format!("{}", managers_treshold)).size(50))
+                        .push(
+                            Column::new()
+                                .push(
+                                    button::transparent(
+                                        &mut self.increment_button,
+                                        Container::new(text::simple("+")),
+                                    )
+                                    .on_press(
+                                        Message::DefineManagerXpubs(
+                                            message::DefineManagerXpubs::ManagersTreshold(
+                                                message::Action::Increment,
+                                            ),
+                                        ),
+                                    ),
+                                )
+                                .push(
+                                    button::transparent(
+                                        &mut self.decrement_button,
+                                        Container::new(text::simple("-")),
+                                    )
+                                    .on_press(
+                                        Message::DefineManagerXpubs(
+                                            message::DefineManagerXpubs::ManagersTreshold(
+                                                message::Action::Decrement,
+                                            ),
+                                        ),
+                                    ),
+                                )
+                                .align_items(Align::Center),
+                        )
+                        .align_items(Align::Center)
+                        .spacing(20),
+                )
+                .align_items(Align::Center)
+                .spacing(10),
+        )
+    }
+}
+
+pub struct SpendingDelay {
+    increment_button: Button,
+    decrement_button: Button,
+}
+
+impl SpendingDelay {
+    pub fn new() -> Self {
+        Self {
+            increment_button: Button::new(),
+            decrement_button: Button::new(),
+        }
+    }
+
+    pub fn render(&mut self, spending_delay: u32) -> Container<Message> {
+        Container::new(
+            Column::new()
+                .push(text::bold(text::simple("Spending delay in blocks:")))
+                .push(
+                    Row::new()
+                        .push(text::simple(&format!("{}", spending_delay)).size(50))
+                        .push(
+                            Column::new()
+                                .push(
+                                    button::transparent(
+                                        &mut self.increment_button,
+                                        Container::new(text::simple("+")),
+                                    )
+                                    .on_press(
+                                        Message::DefineManagerXpubs(
+                                            message::DefineManagerXpubs::SpendingDelay(
+                                                message::Action::Increment,
+                                            ),
+                                        ),
+                                    ),
+                                )
+                                .push(
+                                    button::transparent(
+                                        &mut self.decrement_button,
+                                        Container::new(text::simple("-")),
+                                    )
+                                    .on_press(
+                                        Message::DefineManagerXpubs(
+                                            message::DefineManagerXpubs::SpendingDelay(
+                                                message::Action::Decrement,
+                                            ),
+                                        ),
+                                    ),
+                                )
+                                .align_items(Align::Center),
+                        )
+                        .align_items(Align::Center)
+                        .spacing(20),
+                )
+                .align_items(Align::Center)
+                .spacing(10),
+        )
+    }
+}
+
+pub struct DefineManagerXpubsAsManager {
+    managers_treshold: ManagersTreshold,
+    spending_delay: SpendingDelay,
+    add_xpub_button: Button,
+    add_cosigner_button: Button,
+    our_xpub_input: text_input::State,
+    scroll: scrollable::State,
+    previous_button: Button,
+    save_button: Button,
+}
+
+impl DefineManagerXpubsAsManager {
+    pub fn new() -> Self {
+        Self {
+            our_xpub_input: text_input::State::new(),
+            add_xpub_button: Button::new(),
+            scroll: scrollable::State::new(),
+            previous_button: Button::new(),
+            save_button: Button::new(),
+            add_cosigner_button: Button::new(),
+            spending_delay: SpendingDelay::new(),
+            managers_treshold: ManagersTreshold::new(),
+        }
+    }
+
+    pub fn render<'a>(
+        &'a mut self,
+        managers_treshold: u32,
+        spending_delay: u32,
+        our_xpub: &str,
+        our_xpub_warning: bool,
+        other_xpubs: Vec<Element<'a, Message>>,
+        cosigners: Vec<Element<'a, Message>>,
+    ) -> Element<'a, Message> {
+        let mut manager_xpub_col = Column::new()
+            .push(text::bold(text::simple("Your manager xpub:")))
             .push(
-                Column::new()
-                    .spacing(10)
-                    .push(text::bold(text::simple("Managers xpubs:")))
-                    .push(Column::with_children(manager_xpubs).spacing(10))
-                    .push(
-                        Container::new(
-                            button::white_card_button(
-                                add_xpub_button,
-                                button::button_content(Some(icon::plus_icon()), "Add manager"),
-                            )
-                            .on_press(Message::DefineManagerXpubs(
-                                message::DefineManagerXpubs::AddXpub,
-                            )),
+                TextInput::new(
+                    &mut self.our_xpub_input,
+                    "Your manager xpub",
+                    our_xpub,
+                    |msg| {
+                        Message::DefineManagerXpubs(message::DefineManagerXpubs::OurXpubEdited(msg))
+                    },
+                )
+                .size(15)
+                .padding(10),
+            )
+            .spacing(10);
+
+        if our_xpub_warning {
+            manager_xpub_col = manager_xpub_col
+                .push(text::simple("Please enter a valid xpub").color(color::WARNING));
+        }
+
+        layout(
+            &mut self.scroll,
+            &mut self.previous_button,
+            Column::new()
+                .push(text::bold(text::simple("Define managers")).size(50))
+                .push(
+                    Row::new()
+                        .push(
+                            Container::new(self.managers_treshold.render(managers_treshold))
+                                .width(Length::FillPortion(1))
+                                .align_x(Align::Center),
+                        )
+                        .push(
+                            Container::new(self.spending_delay.render(spending_delay))
+                                .width(Length::FillPortion(1))
+                                .align_x(Align::Center),
                         )
                         .width(Length::Fill),
-                    ),
-            )
-            .push(
-                Column::new()
-                    .spacing(10)
-                    .push(text::bold(text::simple("Cosigners keys:")))
-                    .push(Column::with_children(cosigners).spacing(10))
-                    .push(
-                        Container::new(
-                            button::white_card_button(
-                                add_cosigner_button,
-                                button::button_content(Some(icon::plus_icon()), "Add cosigner"),
+                )
+                .push(manager_xpub_col)
+                .push(
+                    Column::new()
+                        .push(text::bold(text::simple("Other Managers xpubs:")))
+                        .push(Column::with_children(other_xpubs).spacing(10))
+                        .push(
+                            Container::new(
+                                button::white_card_button(
+                                    &mut self.add_xpub_button,
+                                    button::button_content(Some(icon::plus_icon()), "Add manager"),
+                                )
+                                .on_press(
+                                    Message::DefineManagerXpubs(
+                                        message::DefineManagerXpubs::AddXpub,
+                                    ),
+                                ),
                             )
-                            .on_press(Message::DefineManagerXpubs(
-                                message::DefineManagerXpubs::AddCosigner,
-                            )),
+                            .width(Length::Fill),
+                        )
+                        .spacing(10),
+                )
+                .push(
+                    Column::new()
+                        .push(text::bold(text::simple("Cosigners keys:")))
+                        .push(Column::with_children(cosigners).spacing(10))
+                        .push(
+                            Container::new(
+                                button::white_card_button(
+                                    &mut self.add_cosigner_button,
+                                    button::button_content(
+                                        Some(icon::plus_icon()),
+                                        "Add cosigner key",
+                                    ),
+                                )
+                                .on_press(
+                                    Message::DefineManagerXpubs(
+                                        message::DefineManagerXpubs::AddCosigner,
+                                    ),
+                                ),
+                            )
+                            .width(Length::Fill),
+                        )
+                        .spacing(10),
+                )
+                .push(
+                    Row::new()
+                        .push(
+                            button::primary(
+                                &mut self.save_button,
+                                button::button_content(None, "Save"),
+                            )
+                            .on_press(Message::Next),
+                        )
+                        .align_items(Align::Center)
+                        .spacing(20),
+                )
+                .width(Length::Fill)
+                .height(Length::Fill)
+                .padding(100)
+                .spacing(50)
+                .align_items(Align::Center)
+                .into(),
+        )
+    }
+}
+
+pub struct DefineManagerXpubsAsStakeholderOnly {
+    managers_treshold: ManagersTreshold,
+    spending_delay: SpendingDelay,
+    add_cosigner_button: Button,
+    add_xpub_button: Button,
+    scroll: scrollable::State,
+    previous_button: Button,
+    save_button: Button,
+}
+
+impl DefineManagerXpubsAsStakeholderOnly {
+    pub fn new() -> Self {
+        Self {
+            managers_treshold: ManagersTreshold::new(),
+            spending_delay: SpendingDelay::new(),
+            add_cosigner_button: Button::new(),
+            scroll: scrollable::State::new(),
+            previous_button: Button::new(),
+            save_button: Button::new(),
+            add_xpub_button: Button::new(),
+        }
+    }
+    pub fn render<'a>(
+        &'a mut self,
+        managers_treshold: u32,
+        spending_delay: u32,
+        manager_xpubs: Vec<Element<'a, Message>>,
+        cosigners: Vec<Element<'a, Message>>,
+    ) -> Element<'a, Message> {
+        let mut row = Row::new().align_items(Align::Center).spacing(20);
+        if manager_xpubs.is_empty() {
+            row = row.push(button::primary(
+                &mut self.save_button,
+                button::button_content(None, "Save"),
+            ));
+        } else {
+            row = row.push(
+                button::primary(&mut self.save_button, button::button_content(None, "Save"))
+                    .on_press(Message::Next),
+            );
+        }
+
+        layout(
+            &mut self.scroll,
+            &mut self.previous_button,
+            Column::new()
+                .push(text::bold(text::simple("Define managers")).size(50))
+                .push(
+                    Row::new()
+                        .push(
+                            Container::new(self.managers_treshold.render(managers_treshold))
+                                .width(Length::FillPortion(1))
+                                .align_x(Align::Center),
+                        )
+                        .push(
+                            Container::new(self.spending_delay.render(spending_delay))
+                                .width(Length::FillPortion(1))
+                                .align_x(Align::Center),
                         )
                         .width(Length::Fill),
-                    ),
-            )
-            .push(row)
-            .width(Length::Fill)
-            .height(Length::Fill)
-            .padding(100)
-            .spacing(50)
-            .align_items(Align::Center)
-            .into(),
-    )
+                )
+                .push(
+                    Column::new()
+                        .spacing(10)
+                        .push(text::bold(text::simple("Managers xpubs:")))
+                        .push(Column::with_children(manager_xpubs).spacing(10))
+                        .push(
+                            Container::new(
+                                button::white_card_button(
+                                    &mut self.add_xpub_button,
+                                    button::button_content(Some(icon::plus_icon()), "Add manager"),
+                                )
+                                .on_press(
+                                    Message::DefineManagerXpubs(
+                                        message::DefineManagerXpubs::AddXpub,
+                                    ),
+                                ),
+                            )
+                            .width(Length::Fill),
+                        ),
+                )
+                .push(
+                    Column::new()
+                        .spacing(10)
+                        .push(text::bold(text::simple("Cosigners keys:")))
+                        .push(Column::with_children(cosigners).spacing(10))
+                        .push(
+                            Container::new(
+                                button::white_card_button(
+                                    &mut self.add_cosigner_button,
+                                    button::button_content(Some(icon::plus_icon()), "Add cosigner"),
+                                )
+                                .on_press(
+                                    Message::DefineManagerXpubs(
+                                        message::DefineManagerXpubs::AddCosigner,
+                                    ),
+                                ),
+                            )
+                            .width(Length::Fill),
+                        ),
+                )
+                .push(row)
+                .width(Length::Fill)
+                .height(Length::Fill)
+                .padding(100)
+                .spacing(50)
+                .align_items(Align::Center)
+                .into(),
+        )
+    }
 }
 
 fn layout<'a>(

--- a/src/installer/view.rs
+++ b/src/installer/view.rs
@@ -769,6 +769,70 @@ impl DefineCoordinator {
     }
 }
 
+pub struct DefineEmergencyAddress {
+    address_input: text_input::State,
+    scroll: scrollable::State,
+    previous_button: Button,
+    save_button: Button,
+}
+
+impl DefineEmergencyAddress {
+    pub fn new() -> Self {
+        Self {
+            address_input: text_input::State::new(),
+            scroll: scrollable::State::new(),
+            previous_button: Button::new(),
+            save_button: Button::new(),
+        }
+    }
+    pub fn render<'a>(&'a mut self, address: &str, warning: bool) -> Element<'a, Message> {
+        let mut row = Row::new().align_items(Align::Center).spacing(20);
+        if warning {
+            row = row.push(button::primary(
+                &mut self.save_button,
+                button::button_content(None, "Save"),
+            ));
+        } else {
+            row = row.push(
+                button::primary(&mut self.save_button, button::button_content(None, "Save"))
+                    .on_press(Message::Next),
+            );
+        }
+        let mut col = Column::new()
+            .push(text::bold(text::simple("address:")))
+            .push(
+                TextInput::new(
+                    &mut self.address_input,
+                    "address",
+                    address,
+                    Message::DefineEmergencyAddress,
+                )
+                .size(15)
+                .padding(10),
+            )
+            .spacing(10);
+
+        if warning {
+            col = col.push(text::simple("Please enter a valid address").color(color::WARNING))
+        }
+
+        layout(
+            &mut self.scroll,
+            &mut self.previous_button,
+            Column::new()
+                .push(text::bold(text::simple("Define emergency address")).size(50))
+                .push(col)
+                .push(row)
+                .width(Length::Fill)
+                .height(Length::Fill)
+                .padding(100)
+                .spacing(50)
+                .align_items(Align::Center)
+                .into(),
+        )
+    }
+}
+
 fn layout<'a>(
     scroll_state: &'a mut scrollable::State,
     previous_button: &'a mut Button,

--- a/src/installer/view.rs
+++ b/src/installer/view.rs
@@ -840,9 +840,9 @@ impl DefineEmergencyAddress {
             save_button: Button::new(),
         }
     }
-    pub fn render<'a>(&'a mut self, address: &str, warning: bool) -> Element<'a, Message> {
+    pub fn render<'a>(&'a mut self, address: &form::Value<String>) -> Element<'a, Message> {
         let mut row = Row::new().align_items(Align::Center).spacing(20);
-        if warning {
+        if !address.valid {
             row = row.push(
                 button::primary(&mut self.save_button, button::button_content(None, "Next"))
                     .min_width(200),
@@ -854,23 +854,21 @@ impl DefineEmergencyAddress {
                     .min_width(200),
             );
         }
-        let mut col = Column::new()
+        let col = Column::new()
             .push(text::bold(text::simple("address:")))
             .push(
-                TextInput::new(
+                form::Form::new(
                     &mut self.address_input,
                     "address",
                     address,
                     Message::DefineEmergencyAddress,
                 )
+                .warning("Please enter a valid address")
                 .size(15)
-                .padding(10),
+                .padding(10)
+                .render(),
             )
             .spacing(10);
-
-        if warning {
-            col = col.push(text::simple("Please enter a valid address").color(color::WARNING))
-        }
 
         layout(
             &mut self.scroll,
@@ -905,51 +903,50 @@ impl Watchtower {
     }
     pub fn render(
         &mut self,
-        host: &str,
-        noise_key: &str,
-        warning_host: bool,
-        warning_noise_key: bool,
+        host: &form::Value<String>,
+        noise_key: &form::Value<String>,
     ) -> Element<message::DefineWatchtower> {
-        let mut col = Column::new().push(
-            Row::new()
+        Container::new(
+            Column::new()
                 .push(
-                    TextInput::new(
-                        &mut self.host_input,
-                        "Host",
-                        host,
-                        message::DefineWatchtower::HostEdited,
-                    )
-                    .size(15)
-                    .padding(10),
+                    Row::new()
+                        .push(
+                            form::Form::new(
+                                &mut self.host_input,
+                                "Host",
+                                host,
+                                message::DefineWatchtower::HostEdited,
+                            )
+                            .warning("Please enter a valid Host")
+                            .size(15)
+                            .padding(10)
+                            .render(),
+                        )
+                        .push(
+                            form::Form::new(
+                                &mut self.noise_key_input,
+                                "Noise key",
+                                noise_key,
+                                message::DefineWatchtower::NoiseKeyEdited,
+                            )
+                            .warning("Please enter a valid noise key with length > 66")
+                            .size(15)
+                            .padding(10)
+                            .render(),
+                        )
+                        .push(
+                            button::transparent(
+                                &mut self.delete_button,
+                                Container::new(icon::trash_icon()),
+                            )
+                            .on_press(message::DefineWatchtower::Delete),
+                        )
+                        .spacing(5)
+                        .align_items(Align::Center),
                 )
-                .push(
-                    TextInput::new(
-                        &mut self.noise_key_input,
-                        "Noise key",
-                        noise_key,
-                        message::DefineWatchtower::NoiseKeyEdited,
-                    )
-                    .size(15)
-                    .padding(10),
-                )
-                .push(
-                    button::transparent(
-                        &mut self.delete_button,
-                        Container::new(icon::trash_icon()),
-                    )
-                    .on_press(message::DefineWatchtower::Delete),
-                )
-                .spacing(5)
-                .align_items(Align::Center),
-        );
-
-        if warning_host {
-            col = col.push(text::simple("Please enter a valid host").color(color::WARNING))
-        }
-        if warning_noise_key {
-            col = col.push(text::simple("Please enter a valid noise_key").color(color::WARNING))
-        }
-        Container::new(col.spacing(10)).into()
+                .spacing(10),
+        )
+        .into()
     }
 }
 

--- a/src/installer/view.rs
+++ b/src/installer/view.rs
@@ -1,13 +1,12 @@
 use iced::{
     button::State as Button, pick_list, scrollable, text_input, Align, Column, Container, Element,
-    Length, Row, TextInput,
+    Length, Row,
 };
 
 use crate::{
     installer::message::{self, Message},
     revault::Role,
     ui::{
-        color,
         component::{
             button, card, form, image::revault_colored_logo, scroll, text, ContainerBackgroundStyle,
         },
@@ -742,24 +741,9 @@ impl DefineCoordinator {
     }
     pub fn render<'a>(
         &'a mut self,
-        host: &str,
-        noise_key: &str,
-        warning: bool,
+        host: &form::Value<String>,
+        noise_key: &form::Value<String>,
     ) -> Element<'a, Message> {
-        let mut row = Row::new().align_items(Align::Center).spacing(20);
-        if warning {
-            row = row.push(
-                button::primary(&mut self.save_button, button::button_content(None, "Next"))
-                    .min_width(200),
-            );
-        } else {
-            row = row.push(
-                button::primary(&mut self.save_button, button::button_content(None, "Next"))
-                    .on_press(Message::Next)
-                    .min_width(200),
-            );
-        }
-
         layout(
             &mut self.scroll,
             &mut self.previous_button,
@@ -769,13 +753,15 @@ impl DefineCoordinator {
                     Column::new()
                         .push(text::bold(text::simple("Host:")))
                         .push(
-                            TextInput::new(&mut self.host_input, "Host", host, |msg| {
+                            form::Form::new(&mut self.host_input, "Host", host, |msg| {
                                 Message::DefineCoordinator(message::DefineCoordinator::HostEdited(
                                     msg,
                                 ))
                             })
+                            .warning("Incorrect format for a socket address")
                             .size(15)
-                            .padding(10),
+                            .padding(10)
+                            .render(),
                         )
                         .spacing(10),
                 )
@@ -783,7 +769,7 @@ impl DefineCoordinator {
                     Column::new()
                         .push(text::bold(text::simple("Noise key:")))
                         .push(
-                            TextInput::new(
+                            form::Form::new(
                                 &mut self.noise_key_input,
                                 "Noise key",
                                 noise_key,
@@ -793,12 +779,17 @@ impl DefineCoordinator {
                                     )
                                 },
                             )
+                            .warning("key must be hex encoded and 32 bytes long")
                             .size(15)
-                            .padding(10),
+                            .padding(10)
+                            .render(),
                         )
                         .spacing(10),
                 )
-                .push(row)
+                .push(
+                    button::primary(&mut self.save_button, button::button_content(None, "Next"))
+                        .min_width(200),
+                )
                 .width(Length::Fill)
                 .height(Length::Fill)
                 .padding(100)
@@ -1007,44 +998,39 @@ impl Cosigner {
     }
     pub fn render(
         &mut self,
-        host: &str,
-        noise_key: &str,
-        warning_host: bool,
-        warning_noise_key: bool,
+        host: &form::Value<String>,
+        noise_key: &form::Value<String>,
     ) -> Element<message::DefineCosigner> {
-        let mut col = Column::new().push(
+        Container::new(
             Row::new()
                 .push(
-                    TextInput::new(
+                    form::Form::new(
                         &mut self.host_input,
                         "Host",
                         host,
                         message::DefineCosigner::HostEdited,
                     )
+                    .warning("Please enter a valid host")
                     .size(15)
-                    .padding(10),
+                    .padding(10)
+                    .render(),
                 )
                 .push(
-                    TextInput::new(
+                    form::Form::new(
                         &mut self.noise_key_input,
                         "Noise key",
                         noise_key,
                         message::DefineCosigner::NoiseKeyEdited,
                     )
+                    .warning("key must be hex encoded and 32 bytes long")
                     .size(15)
-                    .padding(10),
+                    .padding(10)
+                    .render(),
                 )
                 .spacing(5)
                 .align_items(Align::Center),
-        );
-
-        if warning_host {
-            col = col.push(text::simple("Please enter a valid host").color(color::WARNING))
-        }
-        if warning_noise_key {
-            col = col.push(text::simple("Please enter a valid noise_key").color(color::WARNING))
-        }
-        Container::new(col.spacing(10)).into()
+        )
+        .into()
     }
 }
 

--- a/src/installer/view.rs
+++ b/src/installer/view.rs
@@ -1,6 +1,6 @@
 use iced::{
-    button::State as Button, scrollable, text_input, Align, Column, Container, Element, Length,
-    Row, TextInput,
+    button::State as Button, pick_list, scrollable, text_input, Align, Column, Container, Element,
+    Length, Row, TextInput,
 };
 
 use crate::{
@@ -1081,8 +1081,14 @@ impl DefineCosigners {
         )
     }
 }
+const NETWORKS: [bitcoin::Network; 3] = [
+    bitcoin::Network::Bitcoin,
+    bitcoin::Network::Testnet,
+    bitcoin::Network::Regtest,
+];
 
 pub struct DefineBitcoind {
+    network_input: pick_list::State<bitcoin::Network>,
     address_input: text_input::State,
     cookie_path_input: text_input::State,
     scroll: scrollable::State,
@@ -1093,6 +1099,7 @@ pub struct DefineBitcoind {
 impl DefineBitcoind {
     pub fn new() -> Self {
         Self {
+            network_input: pick_list::State::default(),
             address_input: text_input::State::new(),
             cookie_path_input: text_input::State::new(),
             scroll: scrollable::State::new(),
@@ -1102,6 +1109,7 @@ impl DefineBitcoind {
     }
     pub fn render<'a>(
         &'a mut self,
+        network: &bitcoin::Network,
         address: &str,
         cookie_path: &str,
         warning_address: bool,
@@ -1143,6 +1151,15 @@ impl DefineBitcoind {
             &mut self.previous_button,
             Column::new()
                 .push(text::bold(text::simple("Define bitcoind")).size(50))
+                .push(Container::new(
+                    pick_list::PickList::new(
+                        &mut self.network_input,
+                        &NETWORKS[..],
+                        Some(*network),
+                        |msg| Message::DefineBitcoind(message::DefineBitcoind::NetworkEdited(msg)),
+                    )
+                    .padding(10),
+                ))
                 .push(col_address)
                 .push(col_cookie)
                 .push(

--- a/src/installer/view.rs
+++ b/src/installer/view.rs
@@ -377,12 +377,12 @@ impl ManagersThreshold {
         }
     }
 
-    pub fn render(&mut self, managers_threshold: usize, warning: bool) -> Container<Message> {
+    pub fn render(&mut self, managers_threshold: &form::Value<usize>) -> Container<Message> {
         let mut col = Column::new()
             .push(text::bold(text::simple("Managers threshold:")))
             .push(
                 Row::new()
-                    .push(text::simple(&format!("{}", managers_threshold)).size(50))
+                    .push(text::simple(&format!("{}", managers_threshold.value)).size(50))
                     .push(
                         Column::new()
                             .push(
@@ -419,7 +419,7 @@ impl ManagersThreshold {
             .align_items(Align::Center)
             .spacing(10);
 
-        if warning {
+        if !managers_threshold.valid {
             col = col.push(card::alert_warning(Container::new(text::small(
                 "Impossible threshold",
             ))))
@@ -441,12 +441,12 @@ impl SpendingDelay {
         }
     }
 
-    pub fn render(&mut self, spending_delay: u32, warning: bool) -> Container<Message> {
+    pub fn render(&mut self, spending_delay: &form::Value<u32>) -> Container<Message> {
         let mut col = Column::new()
             .push(text::bold(text::simple("Spending delay in blocks:")))
             .push(
                 Row::new()
-                    .push(text::simple(&format!("{}", spending_delay)).size(50))
+                    .push(text::simple(&format!("{}", spending_delay.value)).size(50))
                     .push(
                         Column::new()
                             .push(
@@ -482,7 +482,7 @@ impl SpendingDelay {
             )
             .align_items(Align::Center)
             .spacing(10);
-        if warning {
+        if !spending_delay.valid {
             col = col.push(card::alert_warning(Container::new(text::small(
                 "Spending delay cannot be equal to zero",
             ))))
@@ -516,10 +516,8 @@ impl DefineManagerXpubsAsManager {
 
     pub fn render<'a>(
         &'a mut self,
-        managers_threshold: usize,
-        threshold_warning: bool,
-        spending_delay: u32,
-        spending_delay_warning: bool,
+        managers_threshold: &form::Value<usize>,
+        spending_delay: &form::Value<u32>,
         our_xpub: &form::Value<String>,
         other_xpubs: Vec<Element<'a, Message>>,
         cosigners: Vec<Element<'a, Message>>,
@@ -548,20 +546,14 @@ impl DefineManagerXpubsAsManager {
             .push(
                 Row::new()
                     .push(
-                        Container::new(
-                            self.managers_threshold
-                                .render(managers_threshold, threshold_warning),
-                        )
-                        .width(Length::FillPortion(1))
-                        .align_x(Align::Center),
+                        Container::new(self.managers_threshold.render(managers_threshold))
+                            .width(Length::FillPortion(1))
+                            .align_x(Align::Center),
                     )
                     .push(
-                        Container::new(
-                            self.spending_delay
-                                .render(spending_delay, spending_delay_warning),
-                        )
-                        .width(Length::FillPortion(1))
-                        .align_x(Align::Center),
+                        Container::new(self.spending_delay.render(spending_delay))
+                            .width(Length::FillPortion(1))
+                            .align_x(Align::Center),
                     )
                     .width(Length::Fill),
             )
@@ -644,10 +636,8 @@ impl DefineManagerXpubsAsStakeholderOnly {
     }
     pub fn render<'a>(
         &'a mut self,
-        managers_threshold: usize,
-        threshold_warning: bool,
-        spending_delay: u32,
-        spending_delay_warning: bool,
+        managers_threshold: &form::Value<usize>,
+        spending_delay: &form::Value<u32>,
         manager_xpubs: Vec<Element<'a, Message>>,
         cosigners: Vec<Element<'a, Message>>,
         warning: Option<&String>,
@@ -674,20 +664,14 @@ impl DefineManagerXpubsAsStakeholderOnly {
             .push(
                 Row::new()
                     .push(
-                        Container::new(
-                            self.managers_threshold
-                                .render(managers_threshold, threshold_warning),
-                        )
-                        .width(Length::FillPortion(1))
-                        .align_x(Align::Center),
+                        Container::new(self.managers_threshold.render(managers_threshold))
+                            .width(Length::FillPortion(1))
+                            .align_x(Align::Center),
                     )
                     .push(
-                        Container::new(
-                            self.spending_delay
-                                .render(spending_delay, spending_delay_warning),
-                        )
-                        .width(Length::FillPortion(1))
-                        .align_x(Align::Center),
+                        Container::new(self.spending_delay.render(spending_delay))
+                            .width(Length::FillPortion(1))
+                            .align_x(Align::Center),
                     )
                     .width(Length::Fill),
             )

--- a/src/installer/view.rs
+++ b/src/installer/view.rs
@@ -145,79 +145,101 @@ pub fn cosigner_key<'a>(
     .into()
 }
 
-pub fn define_stakeholder_xpubs_as_stakeholder<'a>(
-    our_xpub: &str,
-    our_xpub_input: &'a mut text_input::State,
-    our_xpub_warning: bool,
-    add_xpub_button: &'a mut Button,
-    other_xpubs: Vec<Element<'a, Message>>,
-    scroll: &'a mut scrollable::State,
-    previous_button: &'a mut Button,
-    save_button: &'a mut Button,
-    warning: Option<&String>,
-) -> Element<'a, Message> {
-    let mut col = Column::new()
-        .push(text::bold(text::simple("Your stakeholder xpub:")))
-        .push(
-            TextInput::new(our_xpub_input, "Your stakeholder xpub", our_xpub, |msg| {
-                Message::DefineStakeholderXpubs(message::DefineStakeholderXpubs::OurXpubEdited(msg))
-            })
-            .size(15)
-            .padding(10),
-        )
-        .spacing(10);
+pub struct DefineStakeholderXpubsAsStakeholder {
+    our_xpub_input: text_input::State,
+    previous_button: Button,
+    save_button: Button,
+    add_xpub_button: Button,
+    scroll: scrollable::State,
+}
 
-    if our_xpub_warning {
-        col = col.push(text::simple("Please enter a valid xpub").color(color::WARNING));
+impl DefineStakeholderXpubsAsStakeholder {
+    pub fn new() -> Self {
+        Self {
+            our_xpub_input: text_input::State::new(),
+            add_xpub_button: Button::new(),
+            scroll: scrollable::State::new(),
+            previous_button: Button::new(),
+            save_button: Button::new(),
+        }
     }
-
-    let mut content = Column::new()
-        .push(text::bold(text::simple("Define stakeholders")).size(50))
-        .push(col)
-        .push(
-            Column::new()
-                .spacing(10)
-                .push(text::bold(text::simple("Other stakeholders xpubs:")))
-                .push(Column::with_children(other_xpubs).spacing(10))
-                .push(
-                    Container::new(
-                        button::white_card_button(
-                            add_xpub_button,
-                            button::button_content(Some(icon::plus_icon()), "Add stakeholder"),
+    pub fn render<'a>(
+        &'a mut self,
+        our_xpub: &form::Value<String>,
+        other_xpubs: Vec<Element<'a, Message>>,
+        warning: Option<&String>,
+    ) -> Element<'a, Message> {
+        let mut content = Column::new()
+            .push(text::bold(text::simple("Define stakeholders")).size(50))
+            .push(
+                Column::new()
+                    .push(text::bold(text::simple("Your stakeholder xpub:")))
+                    .push(
+                        form::Form::new(
+                            &mut self.our_xpub_input,
+                            "Your stakeholder xpub",
+                            our_xpub,
+                            |msg| {
+                                Message::DefineStakeholderXpubs(
+                                    message::DefineStakeholderXpubs::OurXpubEdited(msg),
+                                )
+                            },
                         )
-                        .on_press(Message::DefineStakeholderXpubs(
-                            message::DefineStakeholderXpubs::AddXpub,
-                        )),
+                        .warning("Please enter a valid xpub")
+                        .size(15)
+                        .padding(10)
+                        .render(),
                     )
-                    .width(Length::Fill),
-                ),
-        )
-        .push(
-            Row::new()
-                .push(
-                    button::primary(save_button, button::button_content(None, "Next"))
+                    .spacing(10),
+            )
+            .push(
+                Column::new()
+                    .spacing(10)
+                    .push(text::bold(text::simple("Other stakeholders xpubs:")))
+                    .push(Column::with_children(other_xpubs).spacing(10))
+                    .push(
+                        Container::new(
+                            button::white_card_button(
+                                &mut self.add_xpub_button,
+                                button::button_content(Some(icon::plus_icon()), "Add stakeholder"),
+                            )
+                            .on_press(Message::DefineStakeholderXpubs(
+                                message::DefineStakeholderXpubs::AddXpub,
+                            )),
+                        )
+                        .width(Length::Fill),
+                    ),
+            )
+            .push(
+                Row::new()
+                    .push(
+                        button::primary(
+                            &mut self.save_button,
+                            button::button_content(None, "Next"),
+                        )
                         .on_press(Message::Next)
                         .min_width(200),
-                )
+                    )
+                    .align_items(Align::Center)
+                    .spacing(20),
+            );
+
+        if let Some(error) = warning {
+            content = content.push(card::alert_warning(Container::new(text::simple(&error))));
+        }
+
+        layout(
+            &mut self.scroll,
+            &mut self.previous_button,
+            content
+                .width(Length::Fill)
+                .height(Length::Fill)
+                .padding(100)
+                .spacing(50)
                 .align_items(Align::Center)
-                .spacing(20),
-        );
-
-    if let Some(error) = warning {
-        content = content.push(card::alert_warning(Container::new(text::simple(&error))));
+                .into(),
+        )
     }
-
-    layout(
-        scroll,
-        previous_button,
-        content
-            .width(Length::Fill)
-            .height(Length::Fill)
-            .padding(100)
-            .spacing(50)
-            .align_items(Align::Center)
-            .into(),
-    )
 }
 
 pub fn define_stakeholder_xpubs_as_manager_only<'a>(

--- a/src/installer/view.rs
+++ b/src/installer/view.rs
@@ -165,7 +165,7 @@ impl DefineStakeholderXpubsAsStakeholder {
         warning: Option<&String>,
     ) -> Element<'a, Message> {
         let mut content = Column::new()
-            .push(text::bold(text::simple("Define stakeholders")).size(50))
+            .push(text::bold(text::simple("Stakeholders information")).size(50))
             .push(
                 Column::new()
                     .push(text::bold(text::simple("Your stakeholder xpub:")))
@@ -283,7 +283,7 @@ pub fn define_stakeholder_xpubs_as_manager_only<'a>(
         scroll,
         previous_button,
         Column::new()
-            .push(text::bold(text::simple("Define stakeholders")).size(50))
+            .push(text::bold(text::simple("Stakeholders information")).size(50))
             .push(content)
             .push(row)
             .width(Length::Fill)
@@ -601,7 +601,7 @@ impl DefineManagerXpubsAsStakeholderOnly {
         }
 
         let mut content = Column::new()
-            .push(text::bold(text::simple("Fill fund management information:")).size(50))
+            .push(text::bold(text::simple("Fund management configuration")).size(50))
             .push(
                 Row::new()
                     .push(

--- a/src/installer/view.rs
+++ b/src/installer/view.rs
@@ -436,16 +436,15 @@ impl DefineManagerXpubsAsManager {
         treshold_warning: bool,
         spending_delay: u32,
         spending_delay_warning: bool,
-        our_xpub: &str,
-        our_xpub_warning: bool,
+        our_xpub: &form::Value<String>,
         other_xpubs: Vec<Element<'a, Message>>,
         cosigners: Vec<Element<'a, Message>>,
         warning: Option<&String>,
     ) -> Element<'a, Message> {
-        let mut manager_xpub_col = Column::new()
+        let manager_xpub_col = Column::new()
             .push(text::bold(text::simple("Your manager xpub:")))
             .push(
-                TextInput::new(
+                form::Form::new(
                     &mut self.our_xpub_input,
                     "Your manager xpub",
                     our_xpub,
@@ -453,15 +452,12 @@ impl DefineManagerXpubsAsManager {
                         Message::DefineManagerXpubs(message::DefineManagerXpubs::OurXpubEdited(msg))
                     },
                 )
+                .warning("Please enter a valid xpub")
                 .size(15)
-                .padding(10),
+                .padding(10)
+                .render(),
             )
             .spacing(10);
-
-        if our_xpub_warning {
-            manager_xpub_col = manager_xpub_col
-                .push(text::simple("Please enter a valid xpub").color(color::WARNING));
-        }
 
         let mut content = Column::new()
             .push(text::bold(text::simple("Define managers")).size(50))

--- a/src/installer/view.rs
+++ b/src/installer/view.rs
@@ -275,7 +275,7 @@ impl ManagersTreshold {
         }
     }
 
-    pub fn render(&mut self, managers_treshold: u32) -> Container<Message> {
+    pub fn render(&mut self, managers_treshold: usize) -> Container<Message> {
         Container::new(
             Column::new()
                 .push(text::bold(text::simple("Managers treshold:")))
@@ -407,7 +407,7 @@ impl DefineManagerXpubsAsManager {
 
     pub fn render<'a>(
         &'a mut self,
-        managers_treshold: u32,
+        managers_treshold: usize,
         spending_delay: u32,
         our_xpub: &str,
         our_xpub_warning: bool,
@@ -544,7 +544,7 @@ impl DefineManagerXpubsAsStakeholderOnly {
     }
     pub fn render<'a>(
         &'a mut self,
-        managers_treshold: u32,
+        managers_treshold: usize,
         spending_delay: u32,
         manager_xpubs: Vec<Element<'a, Message>>,
         cosigners: Vec<Element<'a, Message>>,

--- a/src/installer/view.rs
+++ b/src/installer/view.rs
@@ -954,6 +954,107 @@ impl DefineWatchtowers {
     }
 }
 
+pub struct Cosigner {
+    noise_key_input: text_input::State,
+    host_input: text_input::State,
+}
+
+impl Cosigner {
+    pub fn new() -> Self {
+        Self {
+            noise_key_input: text_input::State::new(),
+            host_input: text_input::State::new(),
+        }
+    }
+    pub fn render(
+        &mut self,
+        host: &str,
+        noise_key: &str,
+        warning_host: bool,
+        warning_noise_key: bool,
+    ) -> Element<message::DefineCosigner> {
+        let mut col = Column::new().push(
+            Row::new()
+                .push(
+                    TextInput::new(
+                        &mut self.host_input,
+                        "Host",
+                        host,
+                        message::DefineCosigner::HostEdited,
+                    )
+                    .size(15)
+                    .padding(10),
+                )
+                .push(
+                    TextInput::new(
+                        &mut self.noise_key_input,
+                        "Noise key",
+                        noise_key,
+                        message::DefineCosigner::NoiseKeyEdited,
+                    )
+                    .size(15)
+                    .padding(10),
+                )
+                .spacing(5)
+                .align_items(Align::Center),
+        );
+
+        if warning_host {
+            col = col.push(text::simple("Please enter a valid host").color(color::WARNING))
+        }
+        if warning_noise_key {
+            col = col.push(text::simple("Please enter a valid noise_key").color(color::WARNING))
+        }
+        Container::new(col.spacing(10)).into()
+    }
+}
+
+pub struct DefineCosigners {
+    scroll: scrollable::State,
+    previous_button: Button,
+    save_button: Button,
+}
+
+impl DefineCosigners {
+    pub fn new() -> Self {
+        Self {
+            scroll: scrollable::State::new(),
+            previous_button: Button::new(),
+            save_button: Button::new(),
+        }
+    }
+    pub fn render<'a>(
+        &'a mut self,
+        watchtowers: Vec<Element<'a, Message>>,
+    ) -> Element<'a, Message> {
+        layout(
+            &mut self.scroll,
+            &mut self.previous_button,
+            Column::new()
+                .push(text::bold(text::simple("Define the cosigners")).size(50))
+                .push(
+                    Column::new()
+                        .push(
+                            Container::new(text::bold(text::simple("The cosigners:")))
+                                .width(Length::Fill),
+                        )
+                        .push(Column::with_children(watchtowers).spacing(10))
+                        .spacing(10),
+                )
+                .push(
+                    button::primary(&mut self.save_button, button::button_content(None, "Save"))
+                        .on_press(Message::Next),
+                )
+                .width(Length::Fill)
+                .height(Length::Fill)
+                .padding(100)
+                .spacing(50)
+                .align_items(Align::Center)
+                .into(),
+        )
+    }
+}
+
 fn layout<'a>(
     scroll_state: &'a mut scrollable::State,
     previous_button: &'a mut Button,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use std::error::Error;
 use std::path::PathBuf;
 
+use iced::{executor, Application, Clipboard, Command, Element, Settings, Subscription};
 use tracing_subscriber::filter::EnvFilter;
 extern crate serde;
 extern crate serde_json;
@@ -12,7 +13,11 @@ mod revault;
 mod revaultd;
 mod ui;
 
-use app::config::{Config, ConfigError, DEFAULT_FILE_NAME};
+use app::{
+    config::{ConfigError, DEFAULT_FILE_NAME},
+    App,
+};
+use installer::Installer;
 use revaultd::config::default_datadir;
 
 enum Args {
@@ -38,7 +43,7 @@ fn parse_args(args: Vec<String>) -> Result<Args, Box<dyn Error>> {
     Err(format!("Unknown arguments '{:?}'.", args).into())
 }
 
-fn log_level_from_config(config: &Config) -> Result<EnvFilter, Box<dyn Error>> {
+fn log_level_from_config(config: &app::Config) -> Result<EnvFilter, Box<dyn Error>> {
     if let Some(level) = &config.log_level {
         match level.as_ref() {
             "info" => EnvFilter::try_new("revault_gui=info").map_err(|e| e.into()),
@@ -53,24 +58,97 @@ fn log_level_from_config(config: &Config) -> Result<EnvFilter, Box<dyn Error>> {
     }
 }
 
+pub enum GUI {
+    Installer(Installer),
+    App(App),
+}
+
+#[derive(Debug, Clone)]
+pub enum Message {
+    Install(installer::Message),
+    Run(app::Message),
+}
+
+pub enum Config {
+    Run(app::Config),
+    Install(PathBuf),
+}
+
+impl Application for GUI {
+    type Executor = executor::Default;
+    type Message = Message;
+    type Flags = Config;
+
+    fn title(&self) -> String {
+        match self {
+            Self::Installer(_) => String::from("Revault Installer"),
+            Self::App(_) => String::from("Revault GUI"),
+        }
+    }
+
+    fn new(config: Config) -> (GUI, Command<Self::Message>) {
+        match config {
+            Config::Install(path) => {
+                let (install, command) = Installer::new(path);
+                (GUI::Installer(install), command.map(Message::Install))
+            }
+            Config::Run(cfg) => {
+                let (application, command) = App::new(cfg);
+                (GUI::App(application), command.map(Message::Run))
+            }
+        }
+    }
+
+    fn update(
+        &mut self,
+        message: Self::Message,
+        clipboard: &mut Clipboard,
+    ) -> Command<Self::Message> {
+        if let Message::Install(installer::Message::Exit(path)) = message {
+            let cfg = app::Config::from_file(&path).unwrap();
+            let (application, command) = App::new(cfg);
+            *self = GUI::App(application);
+            return command.map(Message::Run);
+        }
+        match (self, message) {
+            (Self::Installer(i), Message::Install(msg)) => {
+                i.update(msg, clipboard).map(Message::Install)
+            }
+            (Self::App(i), Message::Run(msg)) => i.update(msg, clipboard).map(Message::Run),
+            _ => Command::none(),
+        }
+    }
+
+    fn subscription(&self) -> Subscription<Self::Message> {
+        match self {
+            Self::Installer(v) => v.subscription().map(Message::Install),
+            Self::App(v) => v.subscription().map(Message::Run),
+        }
+    }
+
+    fn view(&mut self) -> Element<Self::Message> {
+        match self {
+            Self::Installer(v) => v.view().map(Message::Install),
+            Self::App(v) => v.view().map(Message::Run),
+        }
+    }
+}
+
 fn main() -> Result<(), Box<dyn Error>> {
     let args = std::env::args().collect();
 
     let config = match parse_args(args)? {
-        Args::ConfigPath(path) => Config::from_file(&path)?,
+        Args::ConfigPath(path) => Config::Run(app::Config::from_file(&path)?),
         Args::None => {
-            let path = Config::default_path()
+            let path = app::Config::default_path()
                 .map_err(|e| format!("Failed to find revault GUI config: {}", e))?;
 
-            match Config::from_file(&path) {
-                Ok(cfg) => cfg,
+            match app::Config::from_file(&path) {
+                Ok(cfg) => Config::Run(cfg),
                 Err(ConfigError::NotFound) => {
                     let default_datadir_path =
                         default_datadir().expect("Unexpected filesystem error");
-                    if let Err(e) = installer::run(default_datadir_path) {
-                        return Err(format!("Failed to install: {}", e).into());
-                    };
-                    Config::from_file(&path)?
+                    Config::Install(default_datadir_path)
                 }
                 Err(e) => {
                     return Err(format!("Failed to read configuration file: {}", e).into());
@@ -80,14 +158,9 @@ fn main() -> Result<(), Box<dyn Error>> {
         Args::DatadirPath(datadir_path) => {
             let mut path = datadir_path.clone();
             path.push(DEFAULT_FILE_NAME);
-            match Config::from_file(&path) {
-                Ok(cfg) => cfg,
-                Err(ConfigError::NotFound) => {
-                    if let Err(e) = installer::run(datadir_path) {
-                        return Err(format!("Failed to install: {}", e).into());
-                    };
-                    Config::from_file(&path)?
-                }
+            match app::Config::from_file(&path) {
+                Ok(cfg) => Config::Run(cfg),
+                Err(ConfigError::NotFound) => Config::Install(datadir_path),
                 Err(e) => {
                     return Err(format!("Failed to read configuration file: {}", e).into());
                 }
@@ -95,13 +168,19 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
     };
 
+    let level = if let Config::Run(cfg) = &config {
+        log_level_from_config(&cfg)?
+    } else {
+        EnvFilter::try_new("revault_gui=info").unwrap()
+    };
+
     tracing::subscriber::set_global_default(
         tracing_subscriber::FmtSubscriber::builder()
-            .with_env_filter(log_level_from_config(&config)?)
+            .with_env_filter(level)
             .finish(),
     )?;
 
-    if let Err(e) = app::run(config) {
+    if let Err(e) = GUI::run(Settings::with_flags(config)) {
         return Err(format!("Failed to launch UI: {}", e).into());
     };
     Ok(())

--- a/src/revault.rs
+++ b/src/revault.rs
@@ -19,6 +19,9 @@ impl std::fmt::Display for Role {
 
 impl Role {
     pub const ALL: [Role; 2] = [Role::Manager, Role::Stakeholder];
+    pub const MANAGER_ONLY: [Role; 1] = [Role::Manager];
+    pub const STAKEHOLDER_ONLY: [Role; 1] = [Role::Stakeholder];
+    pub const STAKEHOLDER_AND_MANAGER: [Role; 2] = [Role::Stakeholder, Role::Manager];
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/revaultd/config.rs
+++ b/src/revaultd/config.rs
@@ -80,6 +80,8 @@ pub struct Config {
     pub log_level: Option<String>,
 }
 
+pub const DEFAULT_FILE_NAME: &'static str = "revault.toml";
+
 impl Config {
     pub fn from_file(path: &Path) -> Result<Self, ConfigError> {
         let config = std::fs::read(path)
@@ -114,7 +116,7 @@ impl Config {
         let mut datadir = default_datadir().map_err(|_| {
             ConfigError::Unexpected("Could not locate the default datadir.".to_owned())
         })?;
-        datadir.push("revault.toml");
+        datadir.push(DEFAULT_FILE_NAME);
         Ok(datadir)
     }
 }

--- a/src/revaultd/config.rs
+++ b/src/revaultd/config.rs
@@ -1,5 +1,5 @@
 use bitcoin::{util::bip32, Network};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::{
     net::SocketAddr,
     path::{Path, PathBuf},
@@ -8,7 +8,7 @@ use std::{
 // This file is adapted from github.com/re-vault/revaultd:
 
 /// Everything we need to know for talking to bitcoind serenely
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct BitcoindConfig {
     /// The network we are operating on, one of "bitcoin", "testnet", "regtest"
     pub network: Network,
@@ -20,14 +20,14 @@ pub struct BitcoindConfig {
     pub poll_interval_secs: Option<u64>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct WatchtowerConfig {
     pub host: String,
     pub noise_key: String,
 }
 
 /// If we are a stakeholder, we need to connect to our watchtower(s)
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct StakeholderConfig {
     pub xpub: bip32::ExtendedPubKey,
     pub watchtowers: Vec<WatchtowerConfig>,
@@ -35,20 +35,20 @@ pub struct StakeholderConfig {
 }
 
 // Same fields as the WatchtowerConfig struct for now, but leave them separate.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct CosignerConfig {
     pub host: String,
     pub noise_key: String,
 }
 
 /// If we are a manager, we need to connect to cosigning servers
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ManagerConfig {
     pub xpub: bip32::ExtendedPubKey,
     pub cosigners: Vec<CosignerConfig>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ScriptsConfig {
     pub deposit_descriptor: String,
     pub unvault_descriptor: String,
@@ -56,7 +56,7 @@ pub struct ScriptsConfig {
 }
 
 /// Static informations we require to operate
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Config {
     /// Everything we need to know to talk to bitcoind
     pub bitcoind_config: BitcoindConfig,
@@ -118,6 +118,34 @@ impl Config {
         })?;
         datadir.push(DEFAULT_FILE_NAME);
         Ok(datadir)
+    }
+
+    /// returns a revaultd config with empty or dummy values
+    pub fn new() -> Config {
+        Self {
+            bitcoind_config: BitcoindConfig {
+                network: Network::Bitcoin,
+                cookie_path: PathBuf::new(),
+                addr: SocketAddr::new(
+                    std::net::IpAddr::V4(std::net::Ipv4Addr::new(127, 0, 0, 1)),
+                    8080,
+                ),
+                poll_interval_secs: None,
+            },
+            stakeholder_config: None,
+            manager_config: None,
+            scripts_config: ScriptsConfig {
+                deposit_descriptor: "".to_string(),
+                unvault_descriptor: "".to_string(),
+                cpfp_descriptor: "".to_string(),
+            },
+            coordinator_host: "".to_string(),
+            coordinator_noise_key: "".to_string(),
+            coordinator_poll_seconds: None,
+            data_dir: None,
+            daemon: None,
+            log_level: None,
+        }
     }
 }
 

--- a/src/revaultd/config.rs
+++ b/src/revaultd/config.rs
@@ -80,7 +80,7 @@ pub struct Config {
     pub log_level: Option<String>,
 }
 
-pub const DEFAULT_FILE_NAME: &'static str = "revault.toml";
+pub const DEFAULT_FILE_NAME: &str = "revaultd.toml";
 
 impl Config {
     pub fn from_file(path: &Path) -> Result<Self, ConfigError> {

--- a/src/revaultd/config.rs
+++ b/src/revaultd/config.rs
@@ -149,6 +149,12 @@ impl Config {
     }
 }
 
+impl Default for Config {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 // From github.com/revault/revaultd:
 // Get the absolute path to the revault configuration folder.
 ///

--- a/src/revaultd/mod.rs
+++ b/src/revaultd/mod.rs
@@ -302,7 +302,7 @@ pub async fn start_daemon(config_path: &Path, revaultd_path: &Path) -> Result<()
         }
     }
 
-    return Err(RevaultDError::StartError(
+    Err(RevaultDError::StartError(
         "Child did not terminate, do you have `daemon=false` in Revault conf?".to_string(),
-    ));
+    ))
 }

--- a/src/ui/component/button.rs
+++ b/src/ui/component/button.rs
@@ -49,14 +49,20 @@ button!(
 
 pub fn button_content<'a, T: 'a>(icon: Option<iced::Text>, text: &str) -> Container<'a, T> {
     match icon {
-        None => Container::new(text::simple(text)).padding(5),
+        None => Container::new(text::simple(text))
+            .width(iced::Length::Fill)
+            .align_x(iced::Align::Center)
+            .padding(5),
         Some(i) => Container::new(
             Row::new()
                 .push(i)
                 .push(text::simple(text))
                 .spacing(10)
+                .width(iced::Length::Fill)
                 .align_items(iced::Align::Center),
         )
+        .width(iced::Length::Fill)
+        .align_x(iced::Align::Center)
         .padding(5),
     }
 }

--- a/src/ui/component/form.rs
+++ b/src/ui/component/form.rs
@@ -5,7 +5,7 @@ use iced::{
 
 use crate::ui::{color, component::text};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Value<T> {
     pub value: T,
     pub valid: bool,
@@ -65,6 +65,12 @@ where
         self
     }
 
+    /// Sets the [`Form`] with a text size
+    pub fn size(mut self, size: u16) -> Self {
+        self.input = self.input.size(size);
+        self
+    }
+
     pub fn render(self) -> Container<'a, Message> {
         if !self.valid {
             if let Some(message) = self.warning {
@@ -75,11 +81,12 @@ where
                     ])
                     .width(Length::Fill)
                     .spacing(5),
-                );
+                )
+                .width(Length::Fill);
             }
         }
 
-        Container::new(self.input)
+        Container::new(self.input).width(Length::Fill)
     }
 }
 


### PR DESCRIPTION
Add installer

Different use case:
1. --conf is present, the app tries to run and returns error if failure.
2. --datadir is present, the app tries to run and starts installer if config is
   not fund in datadir or datadir does not exist.
3. no flags, the app tries to run with default datadir path, starts installer 
   if config is not fund in default datadir or default datadir does not exist.
   
   close #106 