### PR TITLE
add revaultd::get_vaults

### DIFF
--- a/src/app/state/cmd.rs
+++ b/src/app/state/cmd.rs
@@ -24,8 +24,11 @@ pub async fn get_blockheight(revaultd: Arc<RevaultD>) -> Result<u64, RevaultDErr
 pub async fn list_vaults(
     revaultd: Arc<RevaultD>,
     statuses: Option<&[VaultStatus]>,
+    outpoints: Option<Vec<String>>,
 ) -> Result<Vec<Vault>, RevaultDError> {
-    revaultd.list_vaults(statuses).map(|res| res.vaults)
+    revaultd
+        .list_vaults(statuses, outpoints.as_ref())
+        .map(|res| res.vaults)
 }
 
 pub async fn get_onchain_txs(

--- a/src/app/state/emergency.rs
+++ b/src/app/state/emergency.rs
@@ -100,6 +100,7 @@ impl State for EmergencyState {
                     VaultStatus::Unvaulting,
                     VaultStatus::Unvaulted,
                 ]),
+                None,
             ),
             Message::Vaults,
         )])

--- a/src/app/state/manager.rs
+++ b/src/app/state/manager.rs
@@ -250,7 +250,7 @@ impl State for ManagerHomeState {
         Command::batch(vec![
             Command::perform(get_blockheight(self.revaultd.clone()), Message::BlockHeight),
             Command::perform(
-                list_vaults(self.revaultd.clone(), Some(&VaultStatus::CURRENT)),
+                list_vaults(self.revaultd.clone(), Some(&VaultStatus::CURRENT), None),
                 Message::Vaults,
             ),
             Command::perform(
@@ -669,7 +669,7 @@ impl State for ManagerCreateSendTransactionState {
 
     fn load(&self) -> Command<Message> {
         Command::batch(vec![Command::perform(
-            list_vaults(self.revaultd.clone(), Some(&[VaultStatus::Active])),
+            list_vaults(self.revaultd.clone(), Some(&[VaultStatus::Active]), None),
             Message::Vaults,
         )])
     }

--- a/src/app/state/spend_transaction.rs
+++ b/src/app/state/spend_transaction.rs
@@ -74,7 +74,11 @@ impl State for SpendTransactionState {
                             self.deposit_outpoints = tx.deposit_outpoints;
                             self.psbt = tx.psbt;
                             return Command::perform(
-                                list_vaults(self.revaultd.clone(), None),
+                                list_vaults(
+                                    self.revaultd.clone(),
+                                    None,
+                                    Some(self.deposit_outpoints.clone()),
+                                ),
                                 |res| Message::SpendTx(SpendTxMessage::Inputs(res)),
                             );
                         }

--- a/src/app/state/stakeholder.rs
+++ b/src/app/state/stakeholder.rs
@@ -151,6 +151,7 @@ impl State for StakeholderHomeState {
                 list_vaults(
                     self.revaultd.clone(),
                     Some(&VaultStatus::DEPOSIT_AND_CURRENT),
+                    None,
                 ),
                 Message::Vaults,
             ),
@@ -347,7 +348,7 @@ impl State for StakeholderCreateVaultsState {
                 Message::DepositAddress,
             ),
             Command::perform(
-                list_vaults(self.revaultd.clone(), Some(&[VaultStatus::Funded])),
+                list_vaults(self.revaultd.clone(), Some(&[VaultStatus::Funded]), None),
                 Message::Vaults,
             ),
         ])
@@ -502,6 +503,7 @@ impl State for StakeholderDelegateFundsState {
                     VaultStatus::Activating,
                     VaultStatus::Active,
                 ]),
+                None,
             ),
             Message::Vaults,
         )

--- a/src/app/state/vaults.rs
+++ b/src/app/state/vaults.rs
@@ -98,7 +98,7 @@ impl State for VaultsState {
                 self.loading = true;
                 self.vault_status_filter = statuses;
                 return Command::perform(
-                    list_vaults(self.revaultd.clone(), Some(self.vault_status_filter)),
+                    list_vaults(self.revaultd.clone(), Some(self.vault_status_filter), None),
                     Message::Vaults,
                 );
             }
@@ -128,7 +128,7 @@ impl State for VaultsState {
         Command::batch(vec![
             Command::perform(get_blockheight(self.revaultd.clone()), Message::BlockHeight),
             Command::perform(
-                list_vaults(self.revaultd.clone(), Some(self.vault_status_filter)),
+                list_vaults(self.revaultd.clone(), Some(self.vault_status_filter), None),
                 Message::Vaults,
             ),
         ])

--- a/src/revaultd/mod.rs
+++ b/src/revaultd/mod.rs
@@ -112,8 +112,13 @@ impl RevaultD {
     pub fn list_vaults(
         &self,
         statuses: Option<&[VaultStatus]>,
+        outpoints: Option<&Vec<String>>,
     ) -> Result<ListVaultsResponse, RevaultDError> {
-        self.call("listvaults", statuses.map(|s| vec![s]))
+        let mut args = vec![json!(statuses.unwrap_or(&[]))];
+        if let Some(outpoints) = outpoints {
+            args.push(json!(outpoints));
+        }
+        self.call("listvaults", Some(args))
     }
 
     pub fn list_onchain_transactions(


### PR DESCRIPTION
Retrieve the vaults with a list of outpoints.
This fix the need to retrieve all vaults and filter
them by selected outpoints in the spend_transaction panel.