### PR TITLE
fix home panel: reload models after unselect vault

### DIFF
--- a/src/app/state/manager.rs
+++ b/src/app/state/manager.rs
@@ -185,7 +185,7 @@ impl ManagerHomeState {
         if let Some(selected) = &self.selected_vault {
             if selected.vault.outpoint() == outpoint {
                 self.selected_vault = None;
-                return Command::none();
+                return self.load();
             }
         }
 

--- a/src/app/state/stakeholder.rs
+++ b/src/app/state/stakeholder.rs
@@ -70,7 +70,7 @@ impl StakeholderHomeState {
         if let Some(selected) = &self.selected_vault {
             if selected.vault.outpoint() == outpoint {
                 self.selected_vault = None;
-                return Command::none();
+                return self.load();
             }
         }
 


### PR DESCRIPTION
After a vault is selected and updated the home panel
must be refreshed in order to display the new state.

close #148