### PR TITLE
fix view: list vaults with outpoints

### DIFF
--- a/src/app/view/vault.rs
+++ b/src/app/view/vault.rs
@@ -445,7 +445,7 @@ impl VaultView for VaultListItemView {
                                 .push(vault_badge(&vault))
                                 .push(
                                     Column::new()
-                                        .push(text::bold(text::small(&vault.address)))
+                                        .push(text::bold(text::small(&vault.outpoint())))
                                         .push(text::small(&format!(
                                             "{} ( {} )",
                                             &vault.status, updated_at


### PR DESCRIPTION
Vaults can have same Address or deposit txid.
Vault outpoint is the vault id.

close #91