### PR TITLE
fix dep: bump num-bigint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1871,9 +1871,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d047c1062aa51e256408c560894e5251f08925980e53cf1aa5bd00eec6512"
+checksum = "74e768dff5fb39a41b3bcd30bb25cf989706c90d028d1ad71971987aa309d535"
 dependencies = [
  "autocfg",
  "num-integer",


### PR DESCRIPTION
compilation was broken on nightly:
https://github.com/rust-num/num-bigint/issues/218

cargo update -p num-bigint