### PR TITLE
refac: add generic trait to revaultd client

### DIFF
--- a/src/app/context.rs
+++ b/src/app/context.rs
@@ -1,13 +1,15 @@
 use bitcoin::Network;
 
 use super::menu::Menu;
-use crate::{conversion::Converter, daemon::client::RevaultD, revault::Role};
+use crate::{
+    conversion::Converter, daemon::client::Client, daemon::client::RevaultD, revault::Role,
+};
 use std::sync::Arc;
 
 /// Context is an object passing general information
 /// and service clients through the application components.
-pub struct Context {
-    pub revaultd: Arc<RevaultD>,
+pub struct Context<C: Client> {
+    pub revaultd: Arc<RevaultD<C>>,
     pub converter: Converter,
     pub network: Network,
     pub network_up: bool,
@@ -17,9 +19,9 @@ pub struct Context {
     pub managers_threshold: usize,
 }
 
-impl Context {
+impl<C: Client> Context<C> {
     pub fn new(
-        revaultd: Arc<RevaultD>,
+        revaultd: Arc<RevaultD<C>>,
         converter: Converter,
         network: Network,
         role_edit: bool,

--- a/src/app/state/cmd.rs
+++ b/src/app/state/cmd.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::daemon::{
-    client::{RevaultD, RevaultDError},
+    client::{Client, RevaultD, RevaultDError},
     model::{
         RevocationTransactions, ServersStatuses, SpendTransaction, SpendTx, SpendTxStatus,
         UnvaultTransaction, Vault, VaultStatus, VaultTransactions,
@@ -11,18 +11,18 @@ use crate::daemon::{
 };
 
 /// retrieves a bitcoin address for deposit.
-pub async fn get_deposit_address(
-    revaultd: Arc<RevaultD>,
+pub async fn get_deposit_address<C: Client>(
+    revaultd: Arc<RevaultD<C>>,
 ) -> Result<bitcoin::Address, RevaultDError> {
     revaultd.get_deposit_address().map(|res| res.address)
 }
 
-pub async fn get_blockheight(revaultd: Arc<RevaultD>) -> Result<u64, RevaultDError> {
+pub async fn get_blockheight<C: Client>(revaultd: Arc<RevaultD<C>>) -> Result<u64, RevaultDError> {
     revaultd.get_info().map(|res| res.blockheight)
 }
 
-pub async fn list_vaults(
-    revaultd: Arc<RevaultD>,
+pub async fn list_vaults<C: Client>(
+    revaultd: Arc<RevaultD<C>>,
     statuses: Option<&[VaultStatus]>,
     outpoints: Option<Vec<String>>,
 ) -> Result<Vec<Vault>, RevaultDError> {
@@ -31,8 +31,8 @@ pub async fn list_vaults(
         .map(|res| res.vaults)
 }
 
-pub async fn get_onchain_txs(
-    revaultd: Arc<RevaultD>,
+pub async fn get_onchain_txs<C: Client>(
+    revaultd: Arc<RevaultD<C>>,
     outpoint: String,
 ) -> Result<VaultTransactions, RevaultDError> {
     let list = revaultd.list_onchain_transactions(Some(vec![outpoint]))?;
@@ -45,15 +45,15 @@ pub async fn get_onchain_txs(
     Ok(list.onchain_transactions[0].to_owned())
 }
 
-pub async fn get_revocation_txs(
-    revaultd: Arc<RevaultD>,
+pub async fn get_revocation_txs<C: Client>(
+    revaultd: Arc<RevaultD<C>>,
     outpoint: String,
 ) -> Result<RevocationTransactions, RevaultDError> {
     revaultd.get_revocation_txs(&outpoint)
 }
 
-pub async fn set_revocation_txs(
-    revaultd: Arc<RevaultD>,
+pub async fn set_revocation_txs<C: Client>(
+    revaultd: Arc<RevaultD<C>>,
     outpoint: String,
     emergency_tx: Psbt,
     emergency_unvault_tx: Psbt,
@@ -62,23 +62,23 @@ pub async fn set_revocation_txs(
     revaultd.set_revocation_txs(&outpoint, &emergency_tx, &emergency_unvault_tx, &cancel_tx)
 }
 
-pub async fn get_unvault_tx(
-    revaultd: Arc<RevaultD>,
+pub async fn get_unvault_tx<C: Client>(
+    revaultd: Arc<RevaultD<C>>,
     outpoint: String,
 ) -> Result<UnvaultTransaction, RevaultDError> {
     revaultd.get_unvault_tx(&outpoint)
 }
 
-pub async fn set_unvault_tx(
-    revaultd: Arc<RevaultD>,
+pub async fn set_unvault_tx<C: Client>(
+    revaultd: Arc<RevaultD<C>>,
     outpoint: String,
     unvault_tx: Psbt,
 ) -> Result<(), RevaultDError> {
     revaultd.set_unvault_tx(&outpoint, &unvault_tx)
 }
 
-pub async fn get_spend_tx(
-    revaultd: Arc<RevaultD>,
+pub async fn get_spend_tx<C: Client>(
+    revaultd: Arc<RevaultD<C>>,
     inputs: Vec<String>,
     outputs: HashMap<String, u64>,
     feerate: u32,
@@ -86,36 +86,47 @@ pub async fn get_spend_tx(
     revaultd.get_spend_tx(&inputs, &outputs, &feerate)
 }
 
-pub async fn update_spend_tx(revaultd: Arc<RevaultD>, psbt: Psbt) -> Result<(), RevaultDError> {
+pub async fn update_spend_tx<C: Client>(
+    revaultd: Arc<RevaultD<C>>,
+    psbt: Psbt,
+) -> Result<(), RevaultDError> {
     revaultd.update_spend_tx(&psbt)
 }
 
-pub async fn list_spend_txs(
-    revaultd: Arc<RevaultD>,
+pub async fn list_spend_txs<C: Client>(
+    revaultd: Arc<RevaultD<C>>,
     statuses: Option<&[SpendTxStatus]>,
 ) -> Result<Vec<SpendTx>, RevaultDError> {
     revaultd.list_spend_txs(statuses).map(|res| res.spend_txs)
 }
 
-pub async fn delete_spend_tx(revaultd: Arc<RevaultD>, txid: String) -> Result<(), RevaultDError> {
+pub async fn delete_spend_tx<C: Client>(
+    revaultd: Arc<RevaultD<C>>,
+    txid: String,
+) -> Result<(), RevaultDError> {
     revaultd.delete_spend_tx(&txid)
 }
 
-pub async fn broadcast_spend_tx(
-    revaultd: Arc<RevaultD>,
+pub async fn broadcast_spend_tx<C: Client>(
+    revaultd: Arc<RevaultD<C>>,
     txid: String,
 ) -> Result<(), RevaultDError> {
     revaultd.broadcast_spend_tx(&txid)
 }
 
-pub async fn revault(revaultd: Arc<RevaultD>, outpoint: String) -> Result<(), RevaultDError> {
+pub async fn revault<C: Client>(
+    revaultd: Arc<RevaultD<C>>,
+    outpoint: String,
+) -> Result<(), RevaultDError> {
     revaultd.revault(&outpoint)
 }
 
-pub async fn emergency(revaultd: Arc<RevaultD>) -> Result<(), RevaultDError> {
+pub async fn emergency<C: Client>(revaultd: Arc<RevaultD<C>>) -> Result<(), RevaultDError> {
     revaultd.emergency()
 }
 
-pub async fn get_server_status(revaultd: Arc<RevaultD>) -> Result<ServersStatuses, RevaultDError> {
+pub async fn get_server_status<C: Client>(
+    revaultd: Arc<RevaultD<C>>,
+) -> Result<ServersStatuses, RevaultDError> {
     revaultd.get_server_status()
 }

--- a/src/app/state/emergency.rs
+++ b/src/app/state/emergency.rs
@@ -4,7 +4,7 @@ use iced::{Command, Element};
 
 use super::{cmd::list_vaults, State};
 
-use crate::daemon::model::VaultStatus;
+use crate::daemon::{client::Client, model::VaultStatus};
 
 use crate::app::{
     context::Context, error::Error, message::Message, state::cmd, view::EmergencyView,
@@ -39,8 +39,8 @@ impl EmergencyState {
     }
 }
 
-impl State for EmergencyState {
-    fn update(&mut self, ctx: &Context, message: Message) -> Command<Message> {
+impl<C: Client + Send + Sync + 'static> State<C> for EmergencyState {
+    fn update(&mut self, ctx: &Context<C>, message: Message) -> Command<Message> {
         match message {
             Message::Vaults(res) => match res {
                 Ok(vaults) => {
@@ -71,7 +71,7 @@ impl State for EmergencyState {
         Command::none()
     }
 
-    fn view(&mut self, ctx: &Context) -> Element<Message> {
+    fn view(&mut self, ctx: &Context<C>) -> Element<Message> {
         self.view.view(
             ctx,
             self.vaults_number,
@@ -83,7 +83,7 @@ impl State for EmergencyState {
         )
     }
 
-    fn load(&self, ctx: &Context) -> Command<Message> {
+    fn load(&self, ctx: &Context<C>) -> Command<Message> {
         Command::batch(vec![Command::perform(
             list_vaults(
                 ctx.revaultd.clone(),
@@ -101,8 +101,8 @@ impl State for EmergencyState {
     }
 }
 
-impl From<EmergencyState> for Box<dyn State> {
-    fn from(s: EmergencyState) -> Box<dyn State> {
+impl<C: Client + Send + Sync + 'static> From<EmergencyState> for Box<dyn State<C>> {
+    fn from(s: EmergencyState) -> Box<dyn State<C>> {
         Box::new(s)
     }
 }

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -22,14 +22,15 @@ pub use stakeholder::{
 pub use vaults::VaultsState;
 
 use super::{context::Context, message::Message};
+use crate::daemon::client::Client;
 
-pub trait State {
-    fn view(&mut self, ctx: &Context) -> Element<Message>;
-    fn update(&mut self, ctx: &Context, message: Message) -> Command<Message>;
+pub trait State<C: Client> {
+    fn view(&mut self, ctx: &Context<C>) -> Element<Message>;
+    fn update(&mut self, ctx: &Context<C>, message: Message) -> Command<Message>;
     fn subscription(&self) -> Subscription<Message> {
         Subscription::none()
     }
-    fn load(&self, _ctx: &Context) -> Command<Message> {
+    fn load(&self, _ctx: &Context<C>) -> Command<Message> {
         Command::none()
     }
 }

--- a/src/app/state/settings.rs
+++ b/src/app/state/settings.rs
@@ -14,7 +14,7 @@ use crate::app::{
     view::SettingsView,
 };
 
-use crate::daemon::model::ServersStatuses;
+use crate::daemon::{client::Client, model::ServersStatuses};
 
 #[derive(Debug)]
 pub struct SettingsState {
@@ -37,8 +37,8 @@ impl SettingsState {
     }
 }
 
-impl State for SettingsState {
-    fn update(&mut self, _ctx: &Context, message: Message) -> Command<Message> {
+impl<C: Client + Send + Sync + 'static> State<C> for SettingsState {
+    fn update(&mut self, _ctx: &Context<C>, message: Message) -> Command<Message> {
         match message {
             Message::BlockHeight(b) => {
                 match b {
@@ -62,7 +62,7 @@ impl State for SettingsState {
         }
     }
 
-    fn view(&mut self, ctx: &Context) -> Element<Message> {
+    fn view(&mut self, ctx: &Context<C>) -> Element<Message> {
         self.view.view(
             ctx,
             self.warning.as_ref(),
@@ -72,7 +72,7 @@ impl State for SettingsState {
         )
     }
 
-    fn load(&self, ctx: &Context) -> Command<Message> {
+    fn load(&self, ctx: &Context<C>) -> Command<Message> {
         Command::batch(vec![
             Command::perform(get_blockheight(ctx.revaultd.clone()), Message::BlockHeight),
             Command::perform(
@@ -83,8 +83,8 @@ impl State for SettingsState {
     }
 }
 
-impl From<SettingsState> for Box<dyn State> {
-    fn from(s: SettingsState) -> Box<dyn State> {
+impl<C: Client + Send + Sync + 'static> From<SettingsState> for Box<dyn State<C>> {
+    fn from(s: SettingsState) -> Box<dyn State<C>> {
         Box::new(s)
     }
 }

--- a/src/app/state/sign.rs
+++ b/src/app/state/sign.rs
@@ -13,6 +13,7 @@ use iced::{time, Command, Element, Subscription};
 
 use crate::{
     app::{context::Context, message::SignMessage, view::sign::SignerView},
+    daemon::client::Client,
     hw,
 };
 
@@ -194,7 +195,7 @@ impl<T> Signer<T> {
         }
     }
 
-    pub fn view(&mut self, ctx: &Context) -> Element<SignMessage> {
+    pub fn view<C: Client>(&mut self, ctx: &Context<C>) -> Element<SignMessage> {
         self.view
             .view(ctx, self.channel.is_some(), self.processing, self.signed)
     }

--- a/src/app/state/stakeholder.rs
+++ b/src/app/state/stakeholder.rs
@@ -2,7 +2,10 @@ use std::collections::HashMap;
 
 use iced::{Command, Element, Subscription};
 
-use crate::daemon::model::{self, VaultStatus};
+use crate::daemon::{
+    client::Client,
+    model::{self, VaultStatus},
+};
 
 use crate::app::{
     context::Context,
@@ -61,7 +64,11 @@ impl StakeholderHomeState {
             .collect();
     }
 
-    pub fn on_vault_select(&mut self, ctx: &Context, outpoint: String) -> Command<Message> {
+    pub fn on_vault_select<C: Client + Send + Sync + 'static>(
+        &mut self,
+        ctx: &Context<C>,
+        outpoint: String,
+    ) -> Command<Message> {
         if let Some(selected) = &self.selected_vault {
             if selected.vault.outpoint() == outpoint {
                 self.selected_vault = None;
@@ -102,8 +109,8 @@ impl StakeholderHomeState {
     }
 }
 
-impl State for StakeholderHomeState {
-    fn update(&mut self, ctx: &Context, message: Message) -> Command<Message> {
+impl<C: Client + Sync + Send + 'static> State<C> for StakeholderHomeState {
+    fn update(&mut self, ctx: &Context<C>, message: Message) -> Command<Message> {
         match message {
             Message::Vaults(res) => match res {
                 Ok(vaults) => self.update_vaults(vaults),
@@ -120,7 +127,7 @@ impl State for StakeholderHomeState {
         Command::none()
     }
 
-    fn view(&mut self, ctx: &Context) -> Element<Message> {
+    fn view(&mut self, ctx: &Context<C>) -> Element<Message> {
         if let Some(v) = &mut self.selected_vault {
             return v.view(ctx);
         }
@@ -140,7 +147,7 @@ impl State for StakeholderHomeState {
         Subscription::none()
     }
 
-    fn load(&self, ctx: &Context) -> Command<Message> {
+    fn load(&self, ctx: &Context<C>) -> Command<Message> {
         Command::batch(vec![
             Command::perform(get_blockheight(ctx.revaultd.clone()), Message::BlockHeight),
             Command::perform(
@@ -155,8 +162,8 @@ impl State for StakeholderHomeState {
     }
 }
 
-impl From<StakeholderHomeState> for Box<dyn State> {
-    fn from(s: StakeholderHomeState) -> Box<dyn State> {
+impl<C: Client + Sync + Send + 'static> From<StakeholderHomeState> for Box<dyn State<C>> {
+    fn from(s: StakeholderHomeState) -> Box<dyn State<C>> {
         Box::new(s)
     }
 }
@@ -184,7 +191,11 @@ impl StakeholderCreateVaultsState {
         }
     }
 
-    pub fn on_vault_select(&mut self, ctx: &Context, outpoint: String) -> Command<Message> {
+    pub fn on_vault_select<C: Client + Send + Sync + 'static>(
+        &mut self,
+        ctx: &Context<C>,
+        outpoint: String,
+    ) -> Command<Message> {
         if let Some(selected) = &self.selected_vault {
             if selected.vault.outpoint() == outpoint {
                 if self.deposits.len() == 1
@@ -231,8 +242,8 @@ impl StakeholderCreateVaultsState {
     }
 }
 
-impl State for StakeholderCreateVaultsState {
-    fn update(&mut self, ctx: &Context, message: Message) -> Command<Message> {
+impl<C: Client + Send + Sync + 'static> State<C> for StakeholderCreateVaultsState {
+    fn update(&mut self, ctx: &Context<C>, message: Message) -> Command<Message> {
         match message {
             Message::DepositAddress(res) => match res {
                 Ok(address) => {
@@ -274,7 +285,7 @@ impl State for StakeholderCreateVaultsState {
         Subscription::none()
     }
 
-    fn view(&mut self, ctx: &Context) -> Element<Message> {
+    fn view(&mut self, ctx: &Context<C>) -> Element<Message> {
         if let Some(selected) = &mut self.selected_vault {
             return selected.view(ctx);
         }
@@ -285,7 +296,7 @@ impl State for StakeholderCreateVaultsState {
         )
     }
 
-    fn load(&self, ctx: &Context) -> Command<Message> {
+    fn load(&self, ctx: &Context<C>) -> Command<Message> {
         Command::batch(vec![
             Command::perform(
                 get_deposit_address(ctx.revaultd.clone()),
@@ -299,8 +310,8 @@ impl State for StakeholderCreateVaultsState {
     }
 }
 
-impl From<StakeholderCreateVaultsState> for Box<dyn State> {
-    fn from(s: StakeholderCreateVaultsState) -> Box<dyn State> {
+impl<C: Client + Send + Sync + 'static> From<StakeholderCreateVaultsState> for Box<dyn State<C>> {
+    fn from(s: StakeholderCreateVaultsState) -> Box<dyn State<C>> {
         Box::new(s)
     }
 }
@@ -333,7 +344,11 @@ impl StakeholderDelegateFundsState {
         self.vaults = vaults.into_iter().map(VaultListItem::new).collect();
     }
 
-    pub fn on_vault_select(&mut self, ctx: &Context, outpoint: String) -> Command<Message> {
+    pub fn on_vault_select<C: Client + Send + Sync + 'static>(
+        &mut self,
+        ctx: &Context<C>,
+        outpoint: String,
+    ) -> Command<Message> {
         if let Some(selected) = &self.selected_vault {
             if selected.vault.outpoint() == outpoint {
                 self.selected_vault = None;
@@ -354,7 +369,11 @@ impl StakeholderDelegateFundsState {
         Command::none()
     }
 
-    pub fn on_vault_delegate(&mut self, ctx: &Context, outpoint: String) -> Command<Message> {
+    pub fn on_vault_delegate<C: Client + Send + Sync + 'static>(
+        &mut self,
+        ctx: &Context<C>,
+        outpoint: String,
+    ) -> Command<Message> {
         if let Some(selected) = &mut self.selected_vault {
             if selected.vault.outpoint() == outpoint {
                 return selected
@@ -392,8 +411,8 @@ impl StakeholderDelegateFundsState {
     }
 }
 
-impl State for StakeholderDelegateFundsState {
-    fn update(&mut self, ctx: &Context, message: Message) -> Command<Message> {
+impl<C: Client + Send + Sync + 'static> State<C> for StakeholderDelegateFundsState {
+    fn update(&mut self, ctx: &Context<C>, message: Message) -> Command<Message> {
         match message {
             Message::Vaults(res) => match res {
                 Ok(vaults) => self.update_vaults(vaults),
@@ -414,7 +433,7 @@ impl State for StakeholderDelegateFundsState {
         Command::none()
     }
 
-    fn view(&mut self, ctx: &Context) -> Element<Message> {
+    fn view(&mut self, ctx: &Context<C>) -> Element<Message> {
         if let Some(v) = &mut self.selected_vault {
             return v.view(ctx);
         }
@@ -438,7 +457,7 @@ impl State for StakeholderDelegateFundsState {
         Subscription::none()
     }
 
-    fn load(&self, ctx: &Context) -> Command<Message> {
+    fn load(&self, ctx: &Context<C>) -> Command<Message> {
         Command::perform(
             list_vaults(
                 ctx.revaultd.clone(),
@@ -454,8 +473,8 @@ impl State for StakeholderDelegateFundsState {
     }
 }
 
-impl From<StakeholderDelegateFundsState> for Box<dyn State> {
-    fn from(s: StakeholderDelegateFundsState) -> Box<dyn State> {
+impl<C: Client + Send + Sync + 'static> From<StakeholderDelegateFundsState> for Box<dyn State<C>> {
+    fn from(s: StakeholderDelegateFundsState) -> Box<dyn State<C>> {
         Box::new(s)
     }
 }

--- a/src/app/view/deposit.rs
+++ b/src/app/view/deposit.rs
@@ -7,6 +7,7 @@ use crate::{
         message::Message,
         view::{layout, sidebar::Sidebar},
     },
+    daemon::client::Client,
     ui::component::{button, card, navbar, scroll, text::Text},
 };
 
@@ -35,9 +36,9 @@ impl DepositView {
         self.qr_code = iced::qr_code::State::new(address.to_string()).ok();
     }
 
-    pub fn view<'a>(
+    pub fn view<'a, C: Client>(
         &'a mut self,
-        ctx: &Context,
+        ctx: &Context<C>,
         warning: Option<&Error>,
         address: Option<&bitcoin::Address>,
     ) -> Element<'a, Message> {

--- a/src/app/view/emergency.rs
+++ b/src/app/view/emergency.rs
@@ -2,6 +2,7 @@ use iced::{scrollable, Align, Column, Container, Element, Length, Row};
 
 use crate::{
     app::{context::Context, error::Error, menu::Menu, message::Message},
+    daemon::client::Client,
     ui::{
         color,
         component::{button, card, scroll, text::Text, ContainerBackgroundStyle},
@@ -25,9 +26,9 @@ impl EmergencyView {
         }
     }
 
-    pub fn view<'a>(
+    pub fn view<'a, C: Client>(
         &'a mut self,
-        ctx: &Context,
+        ctx: &Context<C>,
         vaults_number: usize,
         funds_amount: u64,
         warning: Option<&Error>,

--- a/src/app/view/home.rs
+++ b/src/app/view/home.rs
@@ -14,7 +14,7 @@ use crate::{
         message::Message,
         view::{layout, sidebar::Sidebar},
     },
-    daemon::model::VaultStatus,
+    daemon::{client::Client, model::VaultStatus},
     ui::{
         component::{button, card, navbar, scroll, text::Text, TooltipStyle},
         icon::{history_icon, person_check_icon, shield_check_icon, tooltip_icon},
@@ -37,9 +37,9 @@ impl ManagerHomeView {
         }
     }
 
-    pub fn view<'a>(
+    pub fn view<'a, C: Client>(
         &'a mut self,
-        ctx: &Context,
+        ctx: &Context<C>,
         warning: Option<&Error>,
         spend_txs: Vec<Element<'a, Message>>,
         moving_vaults: Vec<Element<'a, Message>>,
@@ -103,8 +103,8 @@ impl ManagerHomeView {
     }
 }
 
-fn manager_overview<'a, T: 'a>(
-    ctx: &Context,
+fn manager_overview<'a, T: 'a, C: Client>(
+    ctx: &Context<C>,
     active_funds: u64,
     inactive_funds: u64,
 ) -> Container<'a, T> {
@@ -162,9 +162,9 @@ impl StakeholderHomeView {
         }
     }
 
-    pub fn view<'a>(
+    pub fn view<'a, C: Client>(
         &'a mut self,
-        ctx: &Context,
+        ctx: &Context<C>,
         warning: Option<&Error>,
         moving_vaults: Vec<Element<'a, Message>>,
         balance: &HashMap<VaultStatus, (u64, u64)>,
@@ -223,9 +223,9 @@ impl StakeholderOverview {
         }
     }
 
-    pub fn view(
+    pub fn view<C: Client>(
         &mut self,
-        ctx: &Context,
+        ctx: &Context<C>,
         overview: &HashMap<VaultStatus, (u64, u64)>,
     ) -> Element<Message> {
         let (nb_total_vaults, total_amount) =
@@ -333,8 +333,8 @@ impl StakeholderOverview {
     }
 }
 
-fn active_funds_overview_card<'a, T: 'a>(
-    ctx: &Context,
+fn active_funds_overview_card<'a, T: 'a, C: Client>(
+    ctx: &Context<C>,
     active: Option<&(u64, u64)>,
 ) -> Container<'a, T> {
     let (nb_active_vaults, active_amount) = active.unwrap_or(&(0, 0));
@@ -394,8 +394,8 @@ fn active_funds_overview_card<'a, T: 'a>(
     card::white(Container::new(col.spacing(20)))
 }
 
-fn secured_funds_overview_card<'a, T: 'a>(
-    ctx: &Context,
+fn secured_funds_overview_card<'a, T: 'a, C: Client>(
+    ctx: &Context<C>,
     secure: Option<&(u64, u64)>,
     securing: Option<&(u64, u64)>,
     activating: Option<&(u64, u64)>,

--- a/src/app/view/manager.rs
+++ b/src/app/view/manager.rs
@@ -12,7 +12,7 @@ use crate::{
         menu::Menu,
         message::{InputMessage, Message, RecipientMessage, SpendTxMessage},
     },
-    daemon::model,
+    daemon::{client::Client, model},
     ui::{
         component::{button, card, form, scroll, separation, text::Text, ContainerBackgroundStyle},
         icon::trash_icon,
@@ -396,9 +396,9 @@ impl ManagerSelectInputsView {
         }
     }
 
-    pub fn view<'a>(
+    pub fn view<'a, C: Client>(
         &'a mut self,
-        ctx: &Context,
+        ctx: &Context<C>,
         inputs: Vec<Element<'a, Message>>,
         input_amount: u64,
         output_amount: u64,
@@ -523,8 +523,8 @@ impl ManagerSelectInputsView {
     }
 }
 
-pub fn manager_send_input_view<'a>(
-    ctx: &Context,
+pub fn manager_send_input_view<'a, C: Client>(
+    ctx: &Context<C>,
     outpoint: &str,
     amount: &u64,
     selected: bool,
@@ -690,8 +690,8 @@ impl ManagerSelectFeeView {
     }
 }
 
-pub fn spend_tx_with_feerate_view<'a, T: 'a>(
-    ctx: &Context,
+pub fn spend_tx_with_feerate_view<'a, T: 'a, C: Client>(
+    ctx: &Context<C>,
     inputs: &[model::Vault],
     psbt: &Psbt,
     change_index: Option<usize>,
@@ -866,9 +866,9 @@ impl ManagerSignView {
         }
     }
 
-    pub fn view<'a>(
+    pub fn view<'a, C: Client>(
         &'a mut self,
-        ctx: &Context,
+        ctx: &Context<C>,
         inputs: &[model::Vault],
         psbt: &Psbt,
         cpfp_index: usize,
@@ -970,9 +970,9 @@ impl ManagerSpendTransactionCreatedView {
         }
     }
 
-    pub fn view<'a>(
+    pub fn view<'a, C: Client>(
         &'a mut self,
-        ctx: &Context,
+        ctx: &Context<C>,
         inputs: &[model::Vault],
         psbt: &Psbt,
         cpfp_index: usize,

--- a/src/app/view/settings/mod.rs
+++ b/src/app/view/settings/mod.rs
@@ -8,6 +8,7 @@ use crate::{
         message::Message,
         view::{layout, sidebar::Sidebar},
     },
+    daemon::client::Client,
     ui::component::{navbar, scroll},
 };
 
@@ -30,9 +31,9 @@ impl SettingsView {
         }
     }
 
-    pub fn view<'a>(
+    pub fn view<'a, C: Client>(
         &'a mut self,
-        ctx: &Context,
+        ctx: &Context<C>,
         warning: Option<&Error>,
         blockheight: u64,
         config: &Config,
@@ -57,8 +58,8 @@ impl SettingsView {
         .into()
     }
 
-    pub fn display_boxes<'a>(
-        ctx: &Context,
+    pub fn display_boxes<'a, C: Client>(
+        ctx: &Context<C>,
         blockheight: u64,
         server_status: Option<ServersStatuses>,
         config: &Config,

--- a/src/app/view/sidebar.rs
+++ b/src/app/view/sidebar.rs
@@ -3,6 +3,7 @@ use iced::{pick_list, Column, Container, Length, Row};
 use crate::revault::Role;
 use crate::{
     app::{context::Context, menu::Menu, message::Message, view::layout},
+    daemon::client::Client,
     ui::{
         color,
         component::{button, separation, text::Text, TransparentPickListStyle},
@@ -43,7 +44,7 @@ impl Sidebar {
         }
     }
 
-    pub fn view(&mut self, context: &Context) -> Container<Message> {
+    pub fn view<C: Client>(&mut self, context: &Context<C>) -> Container<Message> {
         let role = if context.role_edit {
             Container::new(
                 pick_list::PickList::new(

--- a/src/app/view/sign.rs
+++ b/src/app/view/sign.rs
@@ -2,6 +2,7 @@ use iced::{Column, Container, Element, Length};
 
 use crate::{
     app::{context::Context, message::SignMessage},
+    daemon::client::Client,
     ui::{
         component::{button, card, text::Text},
         icon,
@@ -20,9 +21,9 @@ impl SignerView {
         }
     }
 
-    pub fn view(
+    pub fn view<C: Client>(
         &mut self,
-        _ctx: &Context,
+        _ctx: &Context<C>,
         connected: bool,
         processing: bool,
         signed: bool,

--- a/src/app/view/spend_transaction.rs
+++ b/src/app/view/spend_transaction.rs
@@ -10,7 +10,7 @@ use crate::{
         message::{Message, SpendTxMessage},
         view::manager::spend_tx_with_feerate_view,
     },
-    daemon::model,
+    daemon::{client::Client, model},
     ui::{
         color,
         component::{badge, button, card, scroll, text::Text, ContainerBackgroundStyle},
@@ -38,9 +38,9 @@ impl SpendTransactionView {
         }
     }
 
-    pub fn view<'a>(
+    pub fn view<'a, C: Client>(
         &'a mut self,
-        ctx: &Context,
+        ctx: &Context<C>,
         psbt: &Psbt,
         cpfp_index: usize,
         change_index: Option<usize>,
@@ -570,9 +570,9 @@ impl SpendTransactionListItemView {
         }
     }
 
-    pub fn view(
+    pub fn view<C: Client>(
         &mut self,
-        ctx: &Context,
+        ctx: &Context<C>,
         tx: &model::SpendTx,
         spend_amount: u64,
         fees: u64,

--- a/src/app/view/stakeholder.rs
+++ b/src/app/view/stakeholder.rs
@@ -6,6 +6,7 @@ use iced::{
 
 use crate::{
     app::{context::Context, error::Error, menu::Menu, message::Message},
+    daemon::client::Client,
     ui::{
         component::{
             button, card, scroll, separation, text::Text, ContainerBackgroundStyle, TooltipStyle,
@@ -37,9 +38,9 @@ impl StakeholderCreateVaultsView {
         self.qr_code = iced::qr_code::State::new(address.to_string()).ok();
     }
 
-    pub fn view<'a>(
+    pub fn view<'a, C: Client>(
         &'a mut self,
-        _ctx: &Context,
+        _ctx: &Context<C>,
         deposits: Vec<Element<'a, Message>>,
         address: Option<&bitcoin::Address>,
     ) -> Element<'a, Message> {
@@ -153,9 +154,9 @@ impl StakeholderDelegateFundsView {
         }
     }
 
-    pub fn view<'a>(
+    pub fn view<'a, C: Client>(
         &'a mut self,
-        ctx: &Context,
+        ctx: &Context<C>,
         active_balance: &u64,
         activating_balance: &u64,
         vaults: Vec<Element<'a, Message>>,

--- a/src/app/view/vault.rs
+++ b/src/app/view/vault.rs
@@ -13,7 +13,10 @@ use crate::{
 };
 
 use crate::{
-    daemon::model::{BroadcastedTransaction, Vault, VaultStatus, VaultTransactions},
+    daemon::{
+        client::Client,
+        model::{BroadcastedTransaction, Vault, VaultStatus, VaultTransactions},
+    },
     revault::Role,
 };
 
@@ -33,9 +36,9 @@ impl VaultModal {
         }
     }
 
-    pub fn view<'a>(
+    pub fn view<'a, C: Client>(
         &'a mut self,
-        ctx: &Context,
+        ctx: &Context<C>,
         vlt: &Vault,
         warning: Option<&Error>,
         panel_title: &str,
@@ -94,8 +97,8 @@ impl VaultModal {
     }
 }
 
-fn vault<'a>(
-    ctx: &Context,
+fn vault<'a, C: Client>(
+    ctx: &Context<C>,
     copy_button: &'a mut iced::button::State,
     vlt: &Vault,
 ) -> Container<'a, Message> {
@@ -170,9 +173,9 @@ impl VaultOnChainTransactionsPanel {
             action_button: iced::button::State::new(),
         }
     }
-    pub fn view(
+    pub fn view<C: Client>(
         &mut self,
-        ctx: &Context,
+        ctx: &Context<C>,
         vault: &Vault,
         txs: &VaultTransactions,
     ) -> Element<Message> {
@@ -290,8 +293,8 @@ impl VaultOnChainTransactionsPanel {
     }
 }
 
-fn transaction<'a, T: 'a>(
-    ctx: &Context,
+fn transaction<'a, T: 'a, C: Client>(
+    ctx: &Context<C>,
     title: &str,
     transaction: &BroadcastedTransaction,
 ) -> Container<'a, T> {
@@ -335,8 +338,8 @@ fn transaction<'a, T: 'a>(
     )
 }
 
-fn input_and_outputs<'a, T: 'a>(
-    ctx: &Context,
+fn input_and_outputs<'a, T: 'a, C: Client>(
+    ctx: &Context<C>,
     broadcasted: &BroadcastedTransaction,
 ) -> Container<'a, T> {
     let mut col_input = Column::new().push(Text::new("Inputs").bold()).spacing(10);
@@ -398,7 +401,7 @@ fn vault_badge<'a, T: 'a>(vault: &Vault) -> Container<'a, T> {
 
 pub trait VaultView {
     fn new() -> Self;
-    fn view(&mut self, ctx: &Context, vault: &Vault) -> Element<Message>;
+    fn view<C: Client>(&mut self, ctx: &Context<C>, vault: &Vault) -> Element<Message>;
 }
 
 #[derive(Debug, Clone)]
@@ -413,7 +416,7 @@ impl VaultView for VaultListItemView {
         }
     }
 
-    fn view(&mut self, ctx: &Context, vault: &Vault) -> iced::Element<Message> {
+    fn view<C: Client>(&mut self, ctx: &Context<C>, vault: &Vault) -> iced::Element<Message> {
         let updated_at = NaiveDateTime::from_timestamp(vault.updated_at, 0);
         button::white_card_button(
             &mut self.state,
@@ -474,7 +477,7 @@ impl VaultView for SecureVaultListItemView {
         }
     }
 
-    fn view(&mut self, ctx: &Context, vault: &Vault) -> iced::Element<Message> {
+    fn view<C: Client>(&mut self, ctx: &Context<C>, vault: &Vault) -> iced::Element<Message> {
         if vault.status == VaultStatus::Funded || vault.status == VaultStatus::Unconfirmed {
             vault_ack_pending(&mut self.select_button, ctx, vault)
         } else {
@@ -483,7 +486,7 @@ impl VaultView for SecureVaultListItemView {
     }
 }
 
-fn vault_ack_signed<'a, T: 'a>(ctx: &Context, deposit: &Vault) -> Element<'a, T> {
+fn vault_ack_signed<'a, T: 'a, C: Client>(ctx: &Context<C>, deposit: &Vault) -> Element<'a, T> {
     card::white(Container::new(
         Row::new()
             .push(
@@ -518,9 +521,9 @@ fn vault_ack_signed<'a, T: 'a>(ctx: &Context, deposit: &Vault) -> Element<'a, T>
     .into()
 }
 
-fn vault_ack_pending<'a>(
+fn vault_ack_pending<'a, C: Client>(
     state: &'a mut iced::button::State,
-    ctx: &Context,
+    ctx: &Context<C>,
     deposit: &Vault,
 ) -> Element<'a, Message> {
     Container::new(
@@ -579,14 +582,14 @@ impl VaultView for DelegateVaultListItemView {
         }
     }
 
-    fn view(&mut self, ctx: &Context, vault: &Vault) -> iced::Element<Message> {
+    fn view<C: Client>(&mut self, ctx: &Context<C>, vault: &Vault) -> iced::Element<Message> {
         vault_delegate(&mut self.select_button, ctx, vault)
     }
 }
 
-fn vault_delegate<'a>(
+fn vault_delegate<'a, C: Client>(
     state: &'a mut iced::button::State,
-    ctx: &Context,
+    ctx: &Context<C>,
     deposit: &Vault,
 ) -> Element<'a, Message> {
     Container::new(
@@ -639,9 +642,9 @@ impl SecureVaultView {
         SecureVaultView {}
     }
 
-    pub fn view<'a>(
+    pub fn view<'a, C: Client>(
         &'a mut self,
-        ctx: &Context,
+        ctx: &Context<C>,
         warning: Option<&Error>,
         deposit: &Vault,
         signer: Element<'a, VaultMessage>,
@@ -712,9 +715,9 @@ impl DelegateVaultView {
         }
     }
 
-    pub fn view<'a>(
+    pub fn view<'a, C: Client>(
         &'a mut self,
-        _ctx: &Context,
+        _ctx: &Context<C>,
         _vault: &Vault,
         warning: Option<&Error>,
         signer: Element<'a, SignMessage>,
@@ -762,9 +765,9 @@ impl RevaultVaultView {
         }
     }
 
-    pub fn view<'a>(
+    pub fn view<'a, C: Client>(
         &'a mut self,
-        _ctx: &Context,
+        _ctx: &Context<C>,
         _vault: &Vault,
         processing: &bool,
         success: &bool,

--- a/src/app/view/vaults.rs
+++ b/src/app/view/vaults.rs
@@ -7,7 +7,7 @@ use crate::{
         message::{Message, VaultFilterMessage},
         view::{layout, sidebar::Sidebar},
     },
-    daemon::model::VaultStatus,
+    daemon::{client::Client, model::VaultStatus},
     ui::component::{navbar, scroll, text::Text, TransparentPickListStyle},
 };
 
@@ -72,9 +72,9 @@ impl VaultsView {
         }
     }
 
-    pub fn view<'a>(
+    pub fn view<'a, C: Client>(
         &'a mut self,
-        ctx: &Context,
+        ctx: &Context<C>,
         warning: Option<&Error>,
         vaults: Vec<Element<'a, Message>>,
         vault_status_filter: &[VaultStatus],

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,7 +72,7 @@ fn log_level_from_config(config: &app::Config) -> Result<EnvFilter, Box<dyn Erro
 pub enum GUI {
     Installer(Installer),
     Loader(Loader),
-    App(App),
+    App(App<daemon::client::jsonrpc::JsonRPCClient>),
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Add a generic trait `daemon::Client`
The PR is quite verbose because we want the trait as generic compiled at build time and not `dyn` in a `Box`