### PR TITLE
Add tests directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-recursion"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "394b41acee32ce53306b9abfa8ad4df10b73b3c003e5c5da4720cca722010878"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2413,6 +2424,7 @@ dependencies = [
 name = "revault-gui"
 version = "0.0.1"
 dependencies = [
+ "async-recursion",
  "bitcoin",
  "chrono",
  "dirs",
@@ -2895,7 +2907,19 @@ dependencies = [
  "mio 0.7.13",
  "num_cpus",
  "pin-project-lite",
+ "tokio-macros",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54473be61f4ebe4efd09cec9bd5d16fa51d70ea0192213d754d2d500457db110"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,7 @@ chrono = "0.4"
 
 [target.'cfg(windows)'.dependencies]
 uds_windows = "0.1.5"
+
+[dev-dependencies]
+async-recursion = "0.2"
+tokio = {version = "1.9.0", features = ["rt", "macros"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,10 @@ license = "BSD-3-Clause"
 authors = ["Edouard Paris <m@edouard.paris>"]
 edition = "2018"
 
+[[bin]]
+name = "revault-gui"
+path = "src/main.rs"
+
 [dependencies]
 bitcoin = { version = "0.27", features = ["base64", "use-serde"] }
 revault_tx = "0.3.0"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,10 +1,10 @@
 pub mod config;
 pub mod context;
 pub mod menu;
+pub mod message;
+pub mod state;
 
 mod error;
-mod message;
-mod state;
 mod view;
 
 use iced::{Clipboard, Command, Element, Subscription};

--- a/src/app/state/deposit.rs
+++ b/src/app/state/deposit.rs
@@ -14,7 +14,7 @@ use crate::{
 /// give it to its view in order to be rendered.
 #[derive(Debug)]
 pub struct DepositState {
-    address: Option<bitcoin::Address>,
+    pub address: Option<bitcoin::Address>,
     warning: Option<Error>,
 
     /// The deposit view is rendering the address.

--- a/src/daemon/client/mod.rs
+++ b/src/daemon/client/mod.rs
@@ -208,7 +208,7 @@ impl<C: Client> RevaultD<C> {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
-struct Request {}
+pub struct Request {}
 
 /// getinfo
 

--- a/src/daemon/model.rs
+++ b/src/daemon/model.rs
@@ -2,7 +2,7 @@ use bitcoin::{util::psbt::PartiallySignedTransaction, OutPoint, Transaction, Txi
 use serde::{Deserialize, Serialize};
 
 /// getdepositaddress response
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DepositAddress {
     pub address: bitcoin::Address,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,9 @@
+pub mod app;
+pub mod conversion;
+pub mod daemon;
+pub mod installer;
+pub mod loader;
+pub mod revault;
+
+mod hw;
+mod ui;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,21 +7,14 @@ use tracing_subscriber::filter::EnvFilter;
 extern crate serde;
 extern crate serde_json;
 
-mod app;
-mod conversion;
-mod daemon;
-mod hw;
-mod installer;
-mod loader;
-mod revault;
-mod ui;
-
-use app::{config::ConfigError, context::Context, menu::Menu, App};
-use conversion::Converter;
-use daemon::config::default_datadir;
-use installer::Installer;
-use loader::Loader;
-use revault::Role;
+use revault_gui::{
+    app::{self, config::ConfigError, context::Context, menu::Menu, App},
+    conversion::Converter,
+    daemon::{self, config::default_datadir},
+    installer::{self, Installer},
+    loader::{self, Loader},
+    revault::Role,
+};
 
 #[derive(Debug, PartialEq)]
 enum Arg {

--- a/tests/app.rs
+++ b/tests/app.rs
@@ -1,0 +1,68 @@
+mod utils;
+
+use serde_json::json;
+use std::str::FromStr;
+use std::sync::Arc;
+
+use utils::{
+    mock::{DaemonClient, MockedRequests},
+    sandbox::Sandbox,
+};
+
+use revault_gui::{
+    app::{context::Context, menu::Menu, state::DepositState},
+    conversion::Converter,
+    daemon::{
+        client::{GetInfoResponse, Request, RevaultD},
+        config::Config,
+        model::DepositAddress,
+    },
+    revault::Role,
+};
+
+#[tokio::test]
+async fn test_deposit_state() {
+    let address = bitcoin::Address::from_str(
+        "tb1qkldgvljmjpxrjq2ev5qxe8dvhn0dph9q85pwtfkjeanmwdue2akqj4twxj",
+    )
+    .unwrap();
+    let sandbox: Sandbox<DaemonClient, DepositState> = Sandbox::new(DepositState::new());
+    let requests: MockedRequests = [
+        (
+            json!({"method": "getinfo", "params": Option::<Request>::None}),
+            Ok(json!(GetInfoResponse {
+                blockheight: 0,
+                network: "testnet".to_string(),
+                sync: 1.0,
+                version: "0.1".to_string(),
+                managers_threshold: 3
+            })),
+        ),
+        (
+            json!({"method": "getdepositaddress", "params": Option::<Request>::None}),
+            Ok(json!(DepositAddress {
+                address: address.clone()
+            })),
+        ),
+    ]
+    .iter()
+    .cloned()
+    .map(|(k, v)| (k.to_string(), v))
+    .collect();
+
+    let cfg = Config::default();
+    let client = DaemonClient::new(requests);
+    let ctx = Context::new(
+        Arc::new(RevaultD::new(&cfg, client).unwrap()),
+        Converter::new(bitcoin::Network::Bitcoin),
+        bitcoin::Network::Bitcoin,
+        false,
+        Role::Stakeholder,
+        Menu::Vaults,
+        3,
+    );
+
+    let sandbox = sandbox.load(&ctx).await;
+
+    assert_eq!(&address, sandbox.state().address.as_ref().unwrap());
+}

--- a/tests/utils/mock.rs
+++ b/tests/utils/mock.rs
@@ -1,0 +1,54 @@
+use revault_gui::daemon::client::{Client, RevaultDError};
+use serde::{de::DeserializeOwned, Serialize};
+use serde_json::{json, Value};
+use std::collections::HashMap;
+use std::fmt::Debug;
+
+pub type MockedRequests = HashMap<String, Result<Value, RevaultDError>>;
+
+#[derive(Debug, Clone)]
+pub struct DaemonClient {
+    requests: MockedRequests,
+}
+
+impl Client for DaemonClient {
+    type Error = Error;
+    fn request<S: Serialize + Debug, D: DeserializeOwned + Debug>(
+        &self,
+        method: &str,
+        params: Option<S>,
+    ) -> Result<D, Self::Error> {
+        let req = json!({"method": method, "params": params}).to_string();
+        if let Some(res) = self.requests.get(&req) {
+            res.clone()
+                .map(|value| serde_json::from_value(value).unwrap())
+                .map_err(|e| Error::MockedError(e))
+        } else {
+            Err(Error::ResponseNotFound(req))
+        }
+    }
+}
+
+impl DaemonClient {
+    pub fn new(requests: MockedRequests) -> Self {
+        Self { requests }
+    }
+}
+
+#[derive(Debug)]
+pub enum Error {
+    MockedError(RevaultDError),
+    ResponseNotFound(String),
+}
+
+impl From<Error> for RevaultDError {
+    fn from(e: Error) -> RevaultDError {
+        match e {
+            Error::MockedError(error) => error,
+            Error::ResponseNotFound(request) => RevaultDError::UnexpectedError(format!(
+                "mocked response not found for request: {}",
+                request
+            )),
+        }
+    }
+}

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -1,0 +1,2 @@
+pub mod mock;
+pub mod sandbox;

--- a/tests/utils/sandbox.rs
+++ b/tests/utils/sandbox.rs
@@ -1,0 +1,47 @@
+use async_recursion::async_recursion;
+use std::marker::PhantomData;
+
+use revault_gui::{
+    app::{context::Context, message::Message, state::State},
+    daemon::client::Client,
+};
+
+pub struct Sandbox<C: Client + Send + Sync + 'static, S: State<C>> {
+    state: S,
+    marker: PhantomData<C>,
+}
+
+impl<C: Client + Send + Sync + 'static, S: State<C> + Send + 'static> Sandbox<C, S> {
+    pub fn new(state: S) -> Self {
+        return Self {
+            state,
+            marker: PhantomData,
+        };
+    }
+
+    pub fn state(&self) -> &S {
+        &self.state
+    }
+
+    #[async_recursion]
+    pub async fn update(mut self, ctx: &Context<C>, message: Message) -> Self {
+        let cmd = self.state.update(ctx, message);
+        for f in cmd.futures() {
+            let msg = f.await;
+            self = self.update(ctx, msg).await;
+        }
+
+        self
+    }
+
+    #[async_recursion]
+    pub async fn load(mut self, ctx: &Context<C>) -> Self {
+        let cmd = self.state.load(ctx);
+        for f in cmd.futures() {
+            let msg = f.await;
+            self = self.update(ctx, msg).await;
+        }
+
+        self
+    }
+}


### PR DESCRIPTION
based on #229 
now, we can simulate iced runtime for State trait with a simple recursion:
https://github.com/revault/revault-gui/pull/231/files#diff-7522a221ae2213d1626bedc98e42c0a74e686b5415bcede478b53fcd29d9d521R27

and thanks to the daemon::Client trait as generic, we have a simple mock::DaemonClient
https://github.com/revault/revault-gui/pull/231/files#diff-7a3ad6290169e7ae5cb266c5b2b3dc91645936f0bed1b7d6fdfd0ba1b247b50dR10

and it permits us to mock answers to state commands:
https://github.com/revault/revault-gui/pull/231/files#diff-e12e015dc6f52c7159e903d60306c405f5cc3358a30108d7eb7c8a1ae8c22c97R30

and then test the state: for example DepositState load the deposit bitcoin address

https://github.com/revault/revault-gui/pull/231/files#diff-e12e015dc6f52c7159e903d60306c405f5cc3358a30108d7eb7c8a1ae8c22c97R67