### PR TITLE
Remove clippy_check from github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,19 +43,3 @@ jobs:
             components: rustfmt
             override: true
       - run: cargo fmt -- --check
-
-  clippy_check:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install needed libraries
-        run: sudo apt install libudev-dev
-      - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
-        with:
-            toolchain: nightly
-            components: clippy
-            override: true
-      - uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features


### PR DESCRIPTION
Because our development is done through
pull requests from forked repositories,
clippy_check returns an error because of
lack of written rights from the github
token. see:

https://github.com/actions-rs/clippy-check#limitations
https://github.com/actions-rs/clippy-check/issues/2