### PR TITLE
Exclude dummysigner from workspace

### DIFF
--- a/contrib/tools/dummysigner/Cargo.toml
+++ b/contrib/tools/dummysigner/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+# add empty workspace to keep dummysigner out of the revault-gui crates
+[workspace]
+
 [dependencies]
 revault_tx = { version = "0.3.0", features = ["use-serde"] }
 base64 = "0.13.0"


### PR DESCRIPTION
Add an empty workspace section to dummysigner Cargo.toml
in order to exclude it from revault-gui workspace membership.