### PR TITLE
dummysigner: add low level exit handling

### DIFF
--- a/contrib/tools/dummysigner/Cargo.lock
+++ b/contrib/tools/dummysigner/Cargo.lock
@@ -2047,6 +2047,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2228,7 +2237,9 @@ dependencies = [
  "memchr",
  "mio 0.7.13",
  "num_cpus",
+ "once_cell",
  "pin-project-lite",
+ "signal-hook-registry",
  "tokio-macros",
  "winapi 0.3.9",
 ]

--- a/contrib/tools/dummysigner/Cargo.toml
+++ b/contrib/tools/dummysigner/Cargo.toml
@@ -17,7 +17,7 @@ iced_futures = "0.3.0"
 iced_native = "0.4.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
-tokio = {version = "1.9.0", features = ["net", "io-util"]}
+tokio = {version = "1.9.0", features = ["net", "io-util", "signal"]}
 tokio-util = { version = "0.6", features = ["codec"] }
 tokio-serde = {version = "0.8", features = ["json"]}
 toml = "0.5"


### PR DESCRIPTION
- do not rely on iced close_on_exit
- listen to window event and ctrl-c signal to exit
- drop any connection on exit

close #278