### PR TITLE
fix log: set level off for mio

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -330,7 +330,8 @@ pub fn setup_logger(log_level: log::LevelFilter) -> Result<(), fern::InitError> 
         .level(log_level)
         .level_for("iced_wgpu", log::LevelFilter::Off)
         .level_for("gfx_backend_vulkan", log::LevelFilter::Off)
-        .level_for("naga", log::LevelFilter::Off);
+        .level_for("naga", log::LevelFilter::Off)
+        .level_for("mio", log::LevelFilter::Off);
 
     dispatcher.chain(std::io::stdout()).apply()?;
 


### PR DESCRIPTION
Mio logs are quite annoying:
```
[1639730512][mio::poll][TRACE] reregistering event source with poller: token=Token(16), interests=READABLE | WRITABLE
[1639730512][mio::poll][TRACE] reregistering event source with poller: token=Token(16), interests=READABLE | WRITABLE
...
```