### PR TITLE
fix CI ubuntu-latest: pin libudev-dev version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Install needed libraries
         if: matrix.os == 'ubuntu-latest'
-        run: sudo apt install libudev-dev pkg-config libxkbcommon-dev libvulkan-dev
+        run: sudo apt-get update & sudo apt-get install --allow-downgrades libudev1=245.4-4ubuntu3 libudev-dev=245.4-4ubuntu3 pkg-config libxkbcommon-dev libvulkan-dev
       - name: Checkout source code
         uses: actions/checkout@v2
       - name: Install Rust ${{ matrix.toolchain }} toolchain


### PR DESCRIPTION
ci build failed for ubuntu-latest because
libudev-dev_245.4-4ubuntu3.13_amd64.deb
does not exist on azure.archive.ubuntu.com

Tried to use 245.4-4ubuntu3.14 but
apt-get install did not found it.

Version is downgraded to 245.4-4ubuntu3
for libudev1 (required dep of libudev-dev)
and libudev-dev