### PR TITLE
Move blockheight in app context.

### DIFF
--- a/src/app/context.rs
+++ b/src/app/context.rs
@@ -16,6 +16,7 @@ pub type HardwareWallet =
 /// Context is an object passing general information
 /// and service clients through the application components.
 pub struct Context<C: Client> {
+    pub blockheight: u64,
     pub revaultd: Arc<RevaultD<C>>,
     pub converter: Converter,
     pub network: Network,
@@ -36,11 +37,11 @@ impl<C: Client> Context<C> {
         role_edit: bool,
         role: Role,
         menu: Menu,
-        managers_threshold: usize,
         internal_daemon: bool,
         hardware_wallet: Box<dyn Fn() -> Pin<HardwareWallet> + Send + Sync>,
     ) -> Self {
         Self {
+            blockheight: 0,
             revaultd,
             converter,
             role,
@@ -48,7 +49,7 @@ impl<C: Client> Context<C> {
             menu,
             network,
             network_up: true,
-            managers_threshold,
+            managers_threshold: 0,
             internal_daemon,
             hardware_wallet,
         }

--- a/src/app/message.rs
+++ b/src/app/message.rs
@@ -1,6 +1,6 @@
 use bitcoin::util::psbt::PartiallySignedTransaction as Psbt;
 use revault_hwi::{app::revault::RevaultHWI, HWIError};
-use std::{sync::Arc, time::Instant};
+use std::sync::Arc;
 use tokio::sync::Mutex;
 
 use crate::{
@@ -18,6 +18,7 @@ use crate::{
 #[derive(Debug, Clone)]
 pub enum Message {
     Reload,
+    Tick,
     StoppingDaemon(Result<(), RevaultDError>),
     Event(iced_native::Event),
     Clipboard(String),
@@ -72,7 +73,6 @@ pub enum SpendTxMessage {
 
 #[derive(Debug, Clone)]
 pub enum VaultMessage {
-    Tick(Instant),
     ListOnchainTransaction,
     OnChainTransactions(Result<VaultTransactions, RevaultDError>),
     SelectRevault,

--- a/src/app/state/cmd.rs
+++ b/src/app/state/cmd.rs
@@ -17,10 +17,6 @@ pub async fn get_deposit_address<C: Client>(
     revaultd.get_deposit_address().map(|res| res.address)
 }
 
-pub async fn get_blockheight<C: Client>(revaultd: Arc<RevaultD<C>>) -> Result<u64, RevaultDError> {
-    revaultd.get_info().map(|res| res.blockheight)
-}
-
 pub async fn list_vaults<C: Client>(
     revaultd: Arc<RevaultD<C>>,
     statuses: Option<&[VaultStatus]>,

--- a/src/app/state/manager.rs
+++ b/src/app/state/manager.rs
@@ -7,7 +7,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use iced::{Command, Element, Subscription};
 
 use super::{
-    cmd::{get_blockheight, get_spend_tx, list_spend_txs, list_vaults, update_spend_tx},
+    cmd::{get_spend_tx, list_spend_txs, list_vaults, update_spend_tx},
     vault::{Vault, VaultListItem},
     State,
 };
@@ -45,7 +45,6 @@ pub struct ManagerHomeState {
 
     active_funds: u64,
     inactive_funds: u64,
-    blockheight: u64,
     warning: Option<Error>,
 
     moving_vaults: Vec<VaultListItem<VaultListItemView>>,
@@ -67,7 +66,6 @@ impl ManagerHomeState {
             active_funds: 0,
             inactive_funds: 0,
             view: ManagerHomeView::new(),
-            blockheight: 0,
             spendable_outpoints: HashMap::new(),
             moving_vaults: Vec::new(),
             warning: None,
@@ -244,14 +242,6 @@ impl<C: Client + Send + Sync + 'static> State<C> for ManagerHomeState {
                     return selected.update(ctx, msg).map(Message::Vault);
                 }
             }
-            Message::BlockHeight(b) => match b {
-                Ok(height) => {
-                    self.blockheight = height;
-                }
-                Err(e) => {
-                    self.warning = Error::from(e).into();
-                }
-            },
             Message::HistoryEvents(res) => match res {
                 Ok(events) => {
                     self.latest_events = events.into_iter().map(HistoryEventState::new).collect();
@@ -310,7 +300,6 @@ impl<C: Client + Send + Sync + 'static> State<C> for ManagerHomeState {
             Message::HistoryEvents,
         );
         Command::batch(vec![
-            Command::perform(get_blockheight(ctx.revaultd.clone()), Message::BlockHeight),
             Command::perform(
                 list_vaults(ctx.revaultd.clone(), Some(&VaultStatus::CURRENT), None),
                 Message::Vaults,

--- a/src/app/state/stakeholder.rs
+++ b/src/app/state/stakeholder.rs
@@ -15,7 +15,7 @@ use crate::app::{
     menu::Menu,
     message::{Message, SignMessage},
     state::{
-        cmd::{get_blockheight, list_vaults},
+        cmd::list_vaults,
         history::HistoryEventState,
         sign::Device,
         vault::{Vault, VaultListItem},
@@ -172,7 +172,6 @@ impl<C: Client + Sync + Send + 'static> State<C> for StakeholderHomeState {
             Message::HistoryEvents,
         );
         Command::batch(vec![
-            Command::perform(get_blockheight(ctx.revaultd.clone()), Message::BlockHeight),
             Command::perform(
                 list_vaults(
                     ctx.revaultd.clone(),

--- a/src/app/view/settings/mod.rs
+++ b/src/app/view/settings/mod.rs
@@ -25,25 +25,23 @@ impl SettingsView {
         &'a mut self,
         ctx: &Context<C>,
         warning: Option<&Error>,
-        blockheight: u64,
         config: &Config,
         server_status: Option<ServersStatuses>,
     ) -> Element<'a, Message> {
         self.dashboard.view(
             ctx,
             warning,
-            SettingsView::display_boxes(&ctx, blockheight, server_status, &config).spacing(8),
+            SettingsView::display_boxes(&ctx, server_status, &config).spacing(8),
         )
     }
 
     pub fn display_boxes<'a, C: Client>(
         ctx: &Context<C>,
-        blockheight: u64,
         server_status: Option<ServersStatuses>,
         config: &Config,
     ) -> Column<'a, Message> {
         if let Some(server_status) = server_status {
-            let boxes = SettingsBoxes::new(blockheight, server_status);
+            let boxes = SettingsBoxes::new(ctx.blockheight, server_status);
             let mut column = Column::new()
                 .push(boxes.bitcoin.display(config))
                 .push(boxes.coordinator.display(config));

--- a/src/main.rs
+++ b/src/main.rs
@@ -203,17 +203,19 @@ impl Application for GUI {
                 let converter = Converter::new(revaultd.network());
                 let network = revaultd.network();
 
-                let context = Context::new(
+                let mut context = Context::new(
                     revaultd,
                     converter,
                     network,
                     edit_role,
                     role,
                     Menu::Home,
-                    info.managers_threshold,
                     self.daemon_running,
                     Box::new(|| Box::pin(connect_hardware_wallet())),
                 );
+
+                context.blockheight = info.blockheight;
+                context.managers_threshold = info.managers_threshold;
 
                 let (app, command) = App::new(context, config);
                 self.state = State::App(app);

--- a/tests/app.rs
+++ b/tests/app.rs
@@ -73,7 +73,6 @@ async fn test_deposit_state() {
         false,
         Role::Stakeholder,
         Menu::Vaults,
-        3,
         false,
         Box::new(|| Box::pin(no_hardware_wallet())),
     );
@@ -158,7 +157,6 @@ async fn test_emergency_state() {
         false,
         Role::Stakeholder,
         Menu::Vaults,
-        3,
         false,
         Box::new(|| Box::pin(no_hardware_wallet())),
     );
@@ -270,7 +268,6 @@ async fn test_vaults_state() {
         false,
         Role::Stakeholder,
         Menu::Vaults,
-        3,
         false,
         Box::new(|| Box::pin(no_hardware_wallet())),
     );
@@ -390,7 +387,6 @@ async fn test_history_state_filter() {
         false,
         Role::Stakeholder,
         Menu::Vaults,
-        3,
         false,
         Box::new(|| Box::pin(no_hardware_wallet())),
     );
@@ -499,7 +495,6 @@ async fn test_history_state_pagination() {
         false,
         Role::Stakeholder,
         Menu::Vaults,
-        3,
         false,
         Box::new(|| Box::pin(no_hardware_wallet())),
     );
@@ -634,7 +629,6 @@ async fn test_history_state_pagination_batching() {
         false,
         Role::Stakeholder,
         Menu::Vaults,
-        3,
         false,
         Box::new(|| Box::pin(no_hardware_wallet())),
     );


### PR DESCRIPTION
App has a running subscription
to check blockheight every 30s
and store it in its context.

Views will retrieve blockheight
directly from context.

It makes less information to load for states, related to #46  