### PR TITLE
Hex validation for `PrivateNoiseKey`.

### DIFF
--- a/src/installer/step/mod.rs
+++ b/src/installer/step/mod.rs
@@ -148,11 +148,27 @@ impl Step for DefinePrivateNoiseKey {
     fn update(&mut self, message: Message) {
         if let Message::PrivateNoiseKey(msg) = message {
             self.key.value = msg;
-            self.key.valid = self.key.value.as_bytes().len() == 64;
+
+            self.key.valid = true;
+            if let Ok(bytes) = Vec::from_hex(&self.key.value) {
+                if bytes.len() != 32 {
+                    self.key.valid = false;
+                }
+            } else {
+                self.key.valid = false;
+            }
         }
     }
     fn apply(&mut self, ctx: &mut Context, _config: &mut config::Config) -> bool {
-        self.key.valid = self.key.value.as_bytes().len() == 64;
+        self.key.valid = true;
+        if let Ok(bytes) = Vec::from_hex(&self.key.value) {
+            if bytes.len() != 32 {
+                self.key.valid = false;
+            }
+        } else {
+            self.key.valid = false;
+        }
+
         ctx.private_noise_key = self.key.value.clone();
         self.key.valid
     }

--- a/src/installer/view.rs
+++ b/src/installer/view.rs
@@ -233,7 +233,9 @@ impl DefinePrivateNoiseKey {
                 .push(
                     Column::new().spacing(10).push(
                         form::Form::new(&mut self.key_input, "", key, Message::PrivateNoiseKey)
-                            .warning("Key must be a 64 characters hex encoded string")
+                            .warning(
+                                "Please enter a 32 bytes noise private key that is hex encoded",
+                            )
                             .size(20)
                             .padding(10)
                             .render(),


### PR DESCRIPTION
The input of `PrivateNoiseKey` present [here](https://github.com/revault/revault-gui/blob/master/src/installer/view.rs#L217) currently is only constraining the input to 64 bytes, but doesn't check if the string is a valid hex sequence.

Based on the implementation of the validation for `noise_key` for `DefineCoordinator` present [here](https://github.com/revault/revault-gui/blob/master/src/installer/step/mod.rs#L315) the validation for hex sequence have been made as requested in #348 