### PR TITLE
Manual CPFP

### DIFF
--- a/src/app/message.rs
+++ b/src/app/message.rs
@@ -67,6 +67,15 @@ pub enum Message {
     AddWatchtower,
     LoadDaemonConfig(DaemonConfig),
     DaemonConfigLoaded(Result<(), Error>),
+    CPFP(CPFPMessage),
+}
+
+// [ZEE] Addition for CPFP
+#[derive(Debug, Clone)]
+pub enum CPFPMessage {
+    CPFP(String),
+    ConfirmCPFP,
+    CPFPed(Result<(), RevaultDError>),
 }
 
 #[derive(Debug, Clone)]
@@ -99,9 +108,6 @@ pub enum SpendTxMessage {
     Update,
     Updated(Result<(), RevaultDError>),
     WithPriority(bool),
-    // [ZEE] Addition for CPFP
-    CPFP,
-    CPFPed(Result<(), RevaultDError>),
 }
 
 #[derive(Debug, Clone)]

--- a/src/app/message.rs
+++ b/src/app/message.rs
@@ -99,6 +99,9 @@ pub enum SpendTxMessage {
     Update,
     Updated(Result<(), RevaultDError>),
     WithPriority(bool),
+    // [ZEE] Addition for CPFP
+    CPFP,
+    CPFPed(Result<(), RevaultDError>),
 }
 
 #[derive(Debug, Clone)]

--- a/src/app/state/cmd.rs
+++ b/src/app/state/cmd.rs
@@ -89,6 +89,14 @@ pub async fn broadcast_spend_tx(
     revaultd.broadcast_spend_tx(&txid, with_priority)
 }
 
+pub async fn cpfp(
+    revaultd: Arc<dyn Daemon + Send + Sync>,
+    txids: Vec<Txid>,
+    fee_rate: f64,
+) -> Result<(), RevaultDError> {
+    revaultd.cpfp(&txids, fee_rate)
+}
+
 pub async fn emergency(revaultd: Arc<dyn Daemon + Send + Sync>) -> Result<(), RevaultDError> {
     revaultd.emergency()
 }

--- a/src/app/view/spend_transaction.rs
+++ b/src/app/view/spend_transaction.rs
@@ -1,8 +1,8 @@
 use bitcoin::{util::psbt::PartiallySignedTransaction as Psbt, Amount};
 
 use iced::{
-    alignment::Horizontal, scrollable, tooltip, Alignment, Checkbox, Column, Container, Element,
-    Length, Row, Tooltip,
+    alignment::Horizontal, scrollable, text_input, tooltip, Alignment, Checkbox, Column, Container,
+    Element, Length, Row, Tooltip,
 };
 
 use revaultd::revault_tx::transactions::RevaultTransaction;
@@ -541,6 +541,7 @@ impl SpendTransactionBroadcastView {
                         )
                         .spacing(5),
                 )
+                // [ZEE] The button for broadcasting the transaction.
                 .push(
                     button::important(
                         &mut self.confirm_button,
@@ -688,6 +689,85 @@ impl SpendTransactionListItemView {
         )
         .on_press(SpendTxMessage::Select(tx.psbt.psbt().clone()))
         .width(Length::Fill)
+        .into()
+    }
+}
+
+#[derive(Debug)]
+pub struct SpendTransactionCPFPView {
+    cpfp_input: text_input::State,
+    confirm_button: iced::button::State,
+}
+
+impl SpendTransactionCPFPView {
+    pub fn new() -> Self {
+        Self {
+            cpfp_input: text_input::State::new(),
+            confirm_button: iced::button::State::new(),
+        }
+    }
+
+    pub fn view(
+        &mut self,
+        processing: bool,
+        success: bool,
+        feerate: &form::Value<String>,
+        warning: Option<&Error>,
+    ) -> Element<Message> {
+        let mut col_action = Column::new();
+        if let Some(error) = warning {
+            col_action = col_action.push(card::alert_warning(Container::new(
+                Text::new(&error.to_string()).small(),
+            )));
+        }
+
+        if processing {
+            col_action = col_action.push(button::important(
+                &mut self.confirm_button,
+                button::button_content(None, "CPFPing"),
+            ));
+        } else if success {
+            col_action = col_action.push(
+                card::success(Text::new("Transaction has been CPFPed"))
+                    .padding(20)
+                    .width(Length::Fill)
+                    .align_x(Horizontal::Center),
+            );
+        } else {
+            // [ZEE] Check if the transaction has been mined or
+            // needs to be CPFPed above.
+            col_action = col_action
+                .push(Text::new("Transaction has not been mined"))
+                .push(
+                    Row::new()
+                        .push(Text::new("CPFP amount in sat/vbyte:").bold())
+                        .push(
+                            form::Form::new(&mut self.cpfp_input, "CPFP", feerate, |msg| {
+                                Message::SpendTx(SpendTxMessage::CPFP)
+                            })
+                            .warning("Feerate must be a number.")
+                            .size(20)
+                            .padding(10)
+                            .render(),
+                        ),
+                )
+                // [ZEE] The button for broadcasting the transaction.
+                .push(
+                    button::important(
+                        &mut self.confirm_button,
+                        button::button_content(None, "CPFP"),
+                    )
+                    .width(Length::Units(200))
+                    .on_press(Message::SpendTx(SpendTxMessage::CPFP)),
+                );
+        }
+
+        card::white(Container::new(
+            col_action.align_items(Alignment::Center).spacing(20),
+        ))
+        .width(Length::Fill)
+        .align_x(Horizontal::Center)
+        .padding(20)
         .into()
     }
 }

--- a/src/daemon/client/mod.rs
+++ b/src/daemon/client/mod.rs
@@ -221,6 +221,12 @@ impl<C: Client + Debug> Daemon for RevaultD<C> {
         )?;
         Ok(resp.events)
     }
+
+    fn cpfp(&self, txids: &[Txid], feerate: f64) -> Result<(), RevaultDError> {
+        let _res: serde_json::value::Value =
+            self.call("cpfp", Some(vec![json!(txids), json!(feerate)]))?;
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/src/daemon/embedded.rs
+++ b/src/daemon/embedded.rs
@@ -319,4 +319,16 @@ impl Daemon for EmbeddedDaemon {
             .get_history(start, end, limit, kind)
             .map_err(|e| e.into())
     }
+    fn cpfp(&self, txids: &[Txid], feerate: f64) -> Result<(), RevaultDError> {
+        Ok(())
+        // Here we implement the call to the backend.
+        // self.handle
+        //     .as_ref()
+        //     .ok_or(RevaultDError::NoAnswer)?
+        //     .lock()
+        //     .unwrap()
+        //     .control
+        //     .cpfp(txids, feerate)
+        //     .map_err(|e| e.into())
+    }
 }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -114,4 +114,5 @@ pub trait Daemon: Debug {
         end: u32,
         limit: u64,
     ) -> Result<Vec<HistoryEvent>, RevaultDError>;
+    fn cpfp(&self, txids: &[Txid], feerate: f64) -> Result<(), RevaultDError>;
 }


### PR DESCRIPTION
I started working on the gui side of the manual CPFP command implementation. Currently, I'm working on the `SpendTransaction` portion of it. The UI will be the same on the unvault but since `broadcast` already existed for `SpendTransaction` I decided to start from it. I have a few questions before I proceed.

- How can I check if the transaction can be CPFPed, can all spend transactions be CPFPed? 
- How should I throw errors for incorrect format of feerate, I looked at `psbt` from `SharePsbt` and I have also seen such error handling #369, not sure which one should I follow.
- In https://github.com/revault/revault-gui/compare/master...Zshan0:revault-gui:manual_cpfp?expand=1#diff-a5ee58847c74b9596f114a63e0133f107b597d19cb398e24902c5829c5624a51 you can see that I have commented out the actual call because it is not able to detect such method exists in `revaultd`.

One last thing, suppose I want to run my local `revaultd` along with local `revault-gui` on `aquarium` how do I do that?